### PR TITLE
Update to r9705

### DIFF
--- a/applications/difx2fits/src/difx2fits.c
+++ b/applications/difx2fits/src/difx2fits.c
@@ -19,11 +19,11 @@
 //===========================================================================
 // SVN properties (DO NOT CHANGE)
 //
-// $Id: difx2fits.c 9642 2020-08-03 12:12:46Z JanWagner $
+// $Id: difx2fits.c 9689 2020-08-28 10:36:46Z JanWagner $
 // $HeadURL: https://svn.atnf.csiro.au/difx/applications/difx2fits/trunk/src/difx2fits.c $
-// $LastChangedRevision: 9642 $
+// $LastChangedRevision: 9689 $
 // $Author: JanWagner $
-// $LastChangedDate: 2020-08-03 22:12:46 +1000 (Mon, 03 Aug 2020) $
+// $LastChangedDate: 2020-08-28 20:36:46 +1000 (Fri, 28 Aug 2020) $
 //
 //============================================================================
 #include <stdio.h>
@@ -1095,20 +1095,21 @@ static int convertFits(const struct CommandLineOptions *opts, DifxInput **Dset, 
 
 	for(c = 0; c < D->nConfig; ++c)
 	{
-	        if ( D->AntPol == 0 ){
-		   if((D->config[c].polMask & DIFXIO_POL_RL) && (D->config[c].polMask & DIFXIO_POL_XY))
-		   {
-			fprintf(stderr, "Error: both linear and circular polarizations are present.  This combination is still experimental. Use option --antpol if you need.\n");
+		if (D->AntPol == 0)
+		{
+			if(isMixedPolMask(D->config[c].polMask))
+			{
+				fprintf(stderr, "Error: both linear and circular polarizations are present. This combination is still experimental. Use option --antpol if you need.\n");
 
-			return 0;
-		   }
+				return 0;
+			}
 
-		   if(D->config[c].polMask & DIFXIO_POL_ERROR)
-		   {
-			fprintf(stderr, "Error: polarization ather than R, L, X or Y is present. Use option --antpol.\n");
+			if(D->config[c].polMask & DIFXIO_POL_ERROR)
+			{
+				fprintf(stderr, "Error: polarization ather than R, L, X or Y is present. Use option --antpol.\n");
 
-			return 0;
-		   }
+				return 0;
+			}
 		}
 	}
 

--- a/applications/difx2fits/src/fitsUV.c
+++ b/applications/difx2fits/src/fitsUV.c
@@ -19,11 +19,11 @@
 //===========================================================================
 // SVN properties (DO NOT CHANGE)
 //
-// $Id: fitsUV.c 9636 2020-07-31 02:13:03Z LeonidPetrov $
+// $Id: fitsUV.c 9689 2020-08-28 10:36:46Z JanWagner $
 // $HeadURL: https://svn.atnf.csiro.au/difx/applications/difx2fits/trunk/src/fitsUV.c $
-// $LastChangedRevision: 9636 $
-// $Author: LeonidPetrov $
-// $LastChangedDate: 2020-07-31 12:13:03 +1000 (Fri, 31 Jul 2020) $
+// $LastChangedRevision: 9689 $
+// $Author: JanWagner $
+// $LastChangedDate: 2020-08-28 20:36:46 +1000 (Fri, 28 Aug 2020) $
 //
 //============================================================================
 #include "fits.h"
@@ -356,16 +356,17 @@ DifxVis *newDifxVis(const DifxInput *D, int jobId, int pulsarBin, int phaseCentr
 	dv->mjdLastRecord = (double *)calloc(D->nAntenna, sizeof(double));
 
 	/* check for polarization confusion */
-        if ( D->AntPol == 0 ){
-   	     if( ( (polMask & DIFXIO_POL_RL) != 0 && (polMask & DIFXIO_POL_XY) != 0 ) || 
-	           (polMask & DIFXIO_POL_ERROR) != 0 ||
-	           (polMask == 0) )
-	      {
-		fprintf(stderr, "Error: bad polarization combinations : %x\n", polMask);
-		deleteDifxVis(dv);
+	if(D->AntPol == 0)
+	{
+		if(isMixedPolMask(polMask) ||
+			(polMask & DIFXIO_POL_ERROR) != 0 ||
+			(polMask == 0))
+		{
+			fprintf(stderr, "Error: bad polarization combinations : %x\n", polMask);
+			deleteDifxVis(dv);
 
-		return 0;
-	      }
+			return 0;
+		}
 
 	      if(polMask & DIFXIO_POL_R)
 	      {

--- a/applications/difx2mark4/src/difx2mark4.h
+++ b/applications/difx2mark4/src/difx2mark4.h
@@ -30,9 +30,9 @@
 #define EXP_CODE_LEN 4
 #define NUMFILS 500                 // max number of type 1 output files
 #define MAGLIM 10000.0              // threshold magnitude for vis. rejection
-#define MAX_FPPAIRS 5000            // dimensioned for b-lines x chans x pol_prods
-#define MAX_DFRQ 200                // allowed max number of *DiFX* frequencies
-#define NVRMAX 4000000              // max # of vis records
+#define MAX_FPPAIRS 10000           // dimensioned for b-lines x chans x pol_prods
+#define MAX_DFRQ 800                // allowed max number of *DiFX* frequencies
+#define NVRMAX 8000000              // max # of vis records
 
 enum booleans {FALSE, TRUE};
 

--- a/libraries/difxio/difxio/difx_antenna.c
+++ b/libraries/difxio/difxio/difx_antenna.c
@@ -19,11 +19,11 @@
 //===========================================================================
 // SVN properties (DO NOT CHANGE)
 //
-// $Id: difx_antenna.c 9636 2020-07-31 02:13:03Z LeonidPetrov $
+// $Id: difx_antenna.c 9688 2020-08-28 10:18:09Z JanWagner $
 // $HeadURL: https://svn.atnf.csiro.au/difx/libraries/difxio/trunk/difxio/difx_antenna.c $
-// $LastChangedRevision: 9636 $
-// $Author: LeonidPetrov $
-// $LastChangedDate: 2020-07-31 12:13:03 +1000 (Fri, 31 Jul 2020) $
+// $LastChangedRevision: 9688 $
+// $Author: JanWagner $
+// $LastChangedDate: 2020-08-28 20:18:09 +1000 (Fri, 28 Aug 2020) $
 //
 //============================================================================
 
@@ -148,8 +148,8 @@ DifxAntenna *newDifxAntennaArray(int nAntenna)
 	for(a = 0; a < nAntenna; ++a)
 	{
 		da[a].spacecraftId = -1;
-		da[a].pol[0] = " ";
-		da[a].pol[1] = " ";
+		da[a].pol[0] = ' ';
+		da[a].pol[1] = ' ';
 		for(i = 0;  i <MAX_MODEL_ORDER; ++i)
 		{
 			da[a].clockcoeff[i] = 0.0;

--- a/libraries/difxio/difxio/difx_input.c
+++ b/libraries/difxio/difxio/difx_input.c
@@ -19,11 +19,11 @@
 //===========================================================================
 // SVN properties (DO NOT CHANGE)
 //
-// $Id: difx_input.c 9650 2020-08-05 14:06:57Z JanWagner $
+// $Id: difx_input.c 9689 2020-08-28 10:36:46Z JanWagner $
 // $HeadURL: https://svn.atnf.csiro.au/difx/libraries/difxio/trunk/difxio/difx_input.c $
-// $LastChangedRevision: 9650 $
+// $LastChangedRevision: 9689 $
 // $Author: JanWagner $
-// $LastChangedDate: 2020-08-06 00:06:57 +1000 (Thu, 06 Aug 2020) $
+// $LastChangedDate: 2020-08-28 20:36:46 +1000 (Fri, 28 Aug 2020) $
 //
 //============================================================================
 
@@ -405,6 +405,26 @@ int polMaskValue(char polName)
 	}
 }
 
+int isMixedPolMask(const int polmask)
+{
+	int poltypeCount = 0;
+
+	if (polmask & DIFXIO_POL_RL)
+	{
+		poltypeCount++;
+	}
+	if (polmask & DIFXIO_POL_XY)
+	{
+		poltypeCount++;
+	}
+	if (polmask & DIFXIO_POL_HV)
+	{
+		poltypeCount++;
+	}
+
+	return (poltypeCount > 1);
+}
+
 /* This function populates the DifxFreqSet array
  * @param D DifxInput object
  * @return -1 in case of error, 0 otherwise
@@ -550,13 +570,13 @@ static int generateFreqSets(DifxInput *D)
 
 		if(dc->polMask & DIFXIO_POL_ERROR || dc->polMask == 0)
 		{
-			fprintf(stderr, "Error: generateFreqSets: polMask = 0x%03x is unsupported!\n", dc->polMask);
+			fprintf(stderr, "Error: generateFreqSets: polMask = 0x%03x is unsupported by FITS-IDI!\n", dc->polMask);
 
 			return -1;
 		}
-		else if((dc->polMask & DIFXIO_POL_RL) && (dc->polMask & DIFXIO_POL_XY)  && D->AntPol ==  0 )
+		else if(isMixedPolMask(dc->polMask & DIFXIO_POL_RL) && D->AntPol == 0)
 		{
-			fprintf(stderr, "Warning: generateFreqSets: polMask = 0x%03x is unsupported!\n", dc->polMask);
+			fprintf(stderr, "Warning: generateFreqSets: polMask = 0x%03x is unsupported by FITS-IDI!\n", dc->polMask);
 		}
 
 		/* populate polarization matrix for this configuration */

--- a/libraries/difxio/difxio/difx_input.h
+++ b/libraries/difxio/difxio/difx_input.h
@@ -19,11 +19,11 @@
 //===========================================================================
 // SVN properties (DO NOT CHANGE)
 //
-// $Id: difx_input.h 9649 2020-08-05 13:04:32Z JanWagner $
+// $Id: difx_input.h 9689 2020-08-28 10:36:46Z JanWagner $
 // $HeadURL: https://svn.atnf.csiro.au/difx/libraries/difxio/trunk/difxio/difx_input.h $
-// $LastChangedRevision: 9649 $
+// $LastChangedRevision: 9689 $
 // $Author: JanWagner $
-// $LastChangedDate: 2020-08-05 23:04:32 +1000 (Wed, 05 Aug 2020) $
+// $LastChangedDate: 2020-08-28 20:36:46 +1000 (Fri, 28 Aug 2020) $
 //
 //============================================================================
 
@@ -72,6 +72,7 @@
 #define DIFXIO_POL_ERROR		0x1000
 #define DIFXIO_POL_RL			(DIFXIO_POL_R | DIFXIO_POL_L)
 #define DIFXIO_POL_XY			(DIFXIO_POL_X | DIFXIO_POL_Y)
+#define DIFXIO_POL_HV			(DIFXIO_POL_H | DIFXIO_POL_V)
 
 #define DIFXIO_DEFAULT_POLY_ORDER	5
 #define DIFXIO_DEFAULT_POLY_INTERVAL	120
@@ -1040,6 +1041,7 @@ void DifxInputSetThreads(DifxInput *D, int nThread);
 int DifxInputLoadThreads(DifxInput *D);
 int DifxInputWriteThreads(const DifxInput *D);
 int polMaskValue(char polName);
+int isMixedPolMask(const int polmask);
 void resetDifxInputCompatibilityStatistics();
 unsigned int printDifxInputCompatibilityStatistics(int verbose);
 

--- a/sites/MPIfR/Makefile.am
+++ b/sites/MPIfR/Makefile.am
@@ -1,3 +1,4 @@
-SUBDIRS = difxdb/difxarchive difxdb/difxexport difxdb/prepDifx hops misc/getObsFiles misc/datacheckers
+SUBDIRS = difxdb/difxarchive difxdb/difxexport difxdb/prepDifx hops misc/getObsFiles misc/datacheckers mark6
+
 
 

--- a/sites/MPIfR/configure.ac
+++ b/sites/MPIfR/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([mpifr_site], [2.6] )
+AC_INIT([mpifr_site], [2.7] )
 
 
 AM_INIT_AUTOMAKE
@@ -11,5 +11,6 @@ AC_OUTPUT([ \
 	difxdb/prepDifx/Makefile \
 	misc/getObsFiles/Makefile \
 	misc/datacheckers/Makefile \
-	hops/Makefile
+	hops/Makefile \
+	mark6/Makefile
 ])

--- a/sites/MPIfR/hops/Makefile.am
+++ b/sites/MPIfR/hops/Makefile.am
@@ -1,4 +1,4 @@
-dist_bin_SCRIPTS = fplot2pdf packHops.py
+dist_bin_SCRIPTS = fplot2pdf packHops.py parFourfit.sh parFourfitSt.sh parFourfit_auto.sh distFourfit.py
 
 install-exec-hook:
 	mv $(DESTDIR)$(bindir)/packHops.py $(DESTDIR)$(bindir)/packHops

--- a/sites/MPIfR/hops/distFourfit.py
+++ b/sites/MPIfR/hops/distFourfit.py
@@ -1,0 +1,327 @@
+#!/usr/bin/python3
+'''
+Usage: distFourfit.py [-c <controlfile>] [-F <frequency group] [-n <max nr of nodes>]
+                      [-m <difx_machines>] [-f <fourfit wrapper script>]
+                      <expt_root>
+
+Runs fourfit on all baselines of the scans located under ./<expt_root>/. 
+Fourfit is executed in parallel, one instance fitting one baseline of one scan.
+The fourfit instances are distributed over the cluster nodes.
+
+Options:
+   -c <controlfile>      HOPS fourfit control file to use for fringe fitting
+   -F <frequency group>  Frequeny group to process, e.g., S
+   -n <max nr of nodes>  Integer number, how many nodes to use at most
+   -m <difx_machines>    DiFX machines file to use. NB: DiFX format, not MPI machinesfile.
+                         The default is $DIFX_MACHINES when available.
+   -f <wrapper>          Wrapper script that sets up HOPS environment and calls fourfit
+                         The simplest wrapper script would be
+                           <</cluster/hops/fourfit_dtrunk>>
+                           source /data/cluster/difx/DiFX-trunk_64/setup_difx
+                           fourfit $@
+
+Required arguments:
+   <expt_root>           The HOPS Mark4 top-level folder; experiment directory.
+'''
+
+import argparse
+import glob, os, sys, time
+import subprocess
+
+# Note: mpi4py is not used as it needs CentOS openmpi but the MPIfR
+#       cluster runs a custom built Gemmatix/GxHive OpenMPI...
+#
+# Todo: add logging, but: (1) popen() PIPE hangs as too much output, 
+#       (2) fourfit has no --logfile <fn> option
+#       -> use " |& tee <scan_baseline.log> ", despite producing a clutter of thousands (IVS..) of log files?
+
+from difxfile.difxmachines import DifxMachines
+from typing import List, Set
+
+################################################################################################################
+
+DEFAULT_FOURFIT = '/cluster/hops/fourfit_dtrunk'
+DEFAULT_FOURFIT_OPTS = ['-m0', '-u']
+DEFAULT_CF = 'cf_1234'
+DEFAULT_FREQ_GROUP = ''
+DEFAULT_MAX_HOSTS = 80
+CPU_PER_NODE = 4
+
+parser = argparse.ArgumentParser(add_help=False, description='Runs fourfit on all baselines of the scans located under ./<expt_root>/')
+parser.add_argument('-h', '--help',        help='Help', action='store_true')
+parser.add_argument('-a', '--ant',         help='Fit only baselines to these antenna(s). Comma separated 1-letter codes.', dest='antennas', default='')
+parser.add_argument('-F', '--fgroup',      dest='freqgroup', help='Frequeny group to process, e.g., S', default=DEFAULT_FREQ_GROUP)
+parser.add_argument('-f', '--fourfit',     dest='fourfitwrapper', help='Fourfit setup and invocation script to use', default=DEFAULT_FOURFIT)
+parser.add_argument('-c', '--controlfile', dest='controlfile', help='Fourfit control file to use for fringe fitting', default=DEFAULT_CF)
+parser.add_argument('-n', '--maxnodes',    dest='maxnodes', help='Run at most n nodes', default=DEFAULT_MAX_HOSTS)
+parser.add_argument('-m', '--difxmachines',dest='difxmachinesfile', help='Get machines from DiFX machines file', default='')
+parser.add_argument('expt_root', nargs='*')
+
+################################################################################################################
+
+class MachineList:
+	'''
+	Class for keeping a list of hostnames on which fourfit is permitted to be run.
+	Hostnames are collected either from: (a) internal default list, (b) $DIFX_MACHINES env var
+    difx machines file, (c) user-specified DiFX machines file
+	'''
+
+	def __init__(self, machinesfile=None):
+		self._machines = []
+		self.loadMachines(machinesfile)
+
+	def loadMachines(self, machinesfile=None):
+		self._machines = []
+		if machinesfile:
+			return self.parseMachinesFile(machinesfile)
+		if len(os.environ['DIFX_MACHINES']) > 0:
+			print('Getting machine list from $DIFX_MACHINES env file')
+			return self.parseEnvMachinesFile()
+		return self.setDefaultMachines()
+
+	def setDefaultMachines(self) -> List[str]:
+		nCores = 4
+		self._machines = ['fxmanager']
+		self._machines += ['node%02d' % (n) for n in range(2,32)]
+		self._machines = self._machines * 4
+		return True
+
+	def parseMachinesFile(self, machinesfile) -> List[str]:
+		difxmachines = DifxMachines(machinesfile)
+		self._machines = [node.name for node in difxmachines.getComputeNodes()]
+		return len(self._machines) > 0
+
+	def parseEnvMachinesFile(self) -> List[str]:
+		return self.parseMachinesFile(os.environ['DIFX_MACHINES'])
+
+	def machines(self):
+		return self._machines
+
+
+################################################################################################################
+
+class ExperimentDirAnalyzer:
+	'''
+	Inspect the content of subdirectories under an experiment dir (e.g., subdirs under ./1234/).
+	Can optionally limit the inspection to only baselines to specific antennas (1-letter IDs).
+	'''
+
+	def __init__(self, antennaSubset=[]):
+		self.limitToAntennas(antennaSubset)
+
+	def limitToAntennas(self, antennaSubset):
+		self._antennaSubset = antennaSubset
+
+	def listScans(self, rootdir: str) -> List[str]:
+		'''Return a list of subdirectories (scans) under experiment root dir'''
+		scandirs = [dname for dname in glob.glob(rootdir + '/*') if os.path.isdir(dname)]
+		return scandirs
+
+	def listScanBaselines(self, scandir: str, doAuto=False) -> Set[str]:
+		'''Return baselines in subdirectory. Example: ('AX', 'AL', 'AS', 'SX', 'LX', 'SL')'''
+		baselines = set()
+		for fpath in glob.glob(scandir + '/' + '??..*'):
+			fn = os.path.split(os.path.basename(fpath))[-1]
+			if (fn[0] == fn[1]) and not doAuto:
+				continue
+			if self._antennaSubset and not any([antId in fn[0:2] for antId in self._antennaSubset]):
+				continue
+			baselines.add(fn[:2])
+		return baselines
+
+	def listScanFittedBaselines(self, scandir: str, doAuto=False, freqgroup='?') -> Set[str]:
+		'''Return a list of already fringe fitted baselines in subdirectory. Example: ['AX', 'AL', 'AS', 'SX', 'LX', 'SL']'''
+		baselines = set()
+		if len(freqgroup) is not 1:
+			freqgroup = '?'
+		globpattern = scandir + '/' + '??.' + freqgroup + '.*'
+		for fpath in glob.glob(globpattern):
+			fn = os.path.split(os.path.basename(fpath))[-1]
+			if (fn[0] == fn[1]) and not doAuto:
+				pass
+			elif self._antennaSubset and not any([antId in fn[0:2] for antId in self._antennaSubset]):
+				pass
+			else:
+				baselines.add(fn[:2])
+		return baselines
+
+	def generateFourfitJobs(self, exptroot: str, freqgroup: str=''):
+		'''Make a job list: list of (subdir,baseline) tuples'''
+		jobs = []
+		Ncompleted = 0
+		for scan in self.listScans(exptroot):
+			blines = self.listScanBaselines(scan)
+			completed = self.listScanFittedBaselines(scan, freqgroup=freqgroup)
+			blines = list(blines - completed)
+			jobs += zip([scan]*len(blines), blines)
+			Ncompleted += len(completed)
+		print('Fourfit jobs: %d new, %d previously completed' % (len(jobs), Ncompleted))
+		return jobs
+
+
+################################################################################################################
+
+class JobDispatch:
+	'''
+	Launch all jobs across the list of hosts in MachineList.
+
+	If there are more jobs than hosts, a smaller group of jobs is
+	launched first. Upone completion the next group is launched.
+
+ 	Currently, the slowest fourfit in a group becomes the bottleneck; a more
+	dynamic approach with an idle hosts pool fed by pending tasks is ToDo.
+	'''
+
+	def __init__(self, fourfit=DEFAULT_FOURFIT, hopscf=DEFAULT_CF, fourfitopts=DEFAULT_FOURFIT_OPTS):
+		self._fourfit = fourfit
+		self._controlfile = hopscf
+		self._fourfitopts = fourfitopts
+		self._freqgroupname = ''
+		self._freqgrouparg = ''
+		self._machines = []
+		self._maxnodes = 1
+
+	def setFourfitWrapper(self, wrapperpath: str):
+		self._fourfit = wrapperpath
+
+	def setFourfitControlFile(self, controlfile: str):
+		self._controlfile = controlfile
+
+	def setFourfitOptions(self, fourfitopts: str):
+		self._fourfitopts = fourfitopts
+
+	def setFreqGroup(self, freqgroupname: str):
+		if len(freqgroupname) > 1:
+			print("Unexpected frequency group '%s', longer than 1 character" % (freqgroupname))
+		else:
+			self._freqgroupname = freqgroupname
+			if len(freqgroupname) == 0:
+				self._freqgrouparg = ''
+			else:
+				self._freqgrouparg = ":" + self._freqgroupname
+
+	def setMaxNodes(self, N=20):
+		self._maxnodes = N
+
+	def setMachines(self, machines=[]):
+		self._machines = machines
+
+	def _group(self, L: List[str], N: int) -> List[str]:
+		'''Yield successive N-sized group from list L.'''
+		last = len(L)
+		for i in range(0, len(L), N):
+			end = i+N
+			if end > last:
+				end = last
+			yield L[i:end]
+
+	def generateJobs(self, exptroot: str, antennaSubset=None):
+		'''
+		Split the set of scans+baselines under experiment dir into a series of small jobs that run in parallel
+		'''
+		analyzer = ExperimentDirAnalyzer()
+		if antennaSubset:
+		    analyzer.limitToAntennas(antennaSubset)
+		jobs = analyzer.generateFourfitJobs(exptroot, self._freqgroupname)
+		return jobs
+
+	def executeJobs(self, jobs):
+		'''
+		Executes a list of fourfit jobs in parallel.
+		The task is split into a series of smaller jobs if necessary.
+		'''
+		hosts = self._machines * CPU_PER_NODE  # todo: some better approach to this!
+		Jmax = min(len(hosts), self._maxnodes)
+		cwd = os.getcwd()
+
+		jobblocks = self._group(jobs, Jmax)
+		for block in jobblocks:
+
+			subjobs = []
+			for job in block:
+				i = block.index(job)
+				subdir,baseline = job
+				host = hosts[i]
+
+				ssh = ["/usr/bin/ssh", "-t", host]
+				cdwork = ["cd", cwd]
+				fourfit = [self._fourfit] + self._fourfitopts + ['-c', self._controlfile, '-b', baseline + self._freqgrouparg, subdir]
+				cmd = ssh + cdwork + ['&&'] + fourfit
+
+				print ('Fitting %s %s on %s' % (subdir,baseline,host))
+				subjobs.append([subdir,baseline,host,cmd])
+
+			self._runJobgroup(subjobs)
+
+	def _runJobgroup(self, joblist, dryrun=False):
+		'''Launch jobs in parallel and wait for their completion'''
+		if dryrun:
+			for job in joblist:
+				cmd = job[-1]
+				print (cmd)
+			return
+
+		processes = {}
+		processdetails = {}
+		for job in joblist:
+			cmd = job[-1]
+			p = subprocess.Popen(cmd, stdin=None, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=False)
+			processdetails[p.pid] = '%s:%s on %s' % (job[0],job[1],job[2])
+			processes[p.pid] = p
+
+		while processes:
+
+			completed = {}
+			for pid in processes.keys():
+				if pid in completed:
+					continue
+				rc = processes[pid].poll()
+				if rc is not None:
+					(s,rc) = processes[pid].communicate()
+					self._cleanTerm()
+					print ('Finished %s, %d remain\n' % (processdetails[pid], len(processes) - len(completed) - 1), flush=True)
+					completed[pid] = 1
+
+			if len(completed) > 0:
+				for pid in completed.keys():
+					del processes[pid]
+					del processdetails[pid]
+
+		self._cleanTerm()
+		print('Done')
+
+	def _cleanTerm(self):
+		'''Reset terminal. Workaround for SSH+popen() which mess up the local terminal such that print() newlines cease to work'''
+		p = subprocess.Popen(["/usr/bin/stty", "sane"], stdin=None, stdout=None, stderr=None, close_fds=True, shell=False)
+		p.communicate()
+
+################################################################################################################
+
+if __name__ == "__main__":
+
+	args = parser.parse_args(sys.argv[1:])
+	if args.help or len(args.expt_root) != 1:
+		print(__doc__)
+		sys.exit(0)
+
+	nodepool = MachineList()
+	handler = JobDispatch()
+
+	if args.difxmachinesfile:
+		nodepool.loadMachines(difxmachinesfile)
+
+	expt_path = args.expt_root[0]
+	antennaSubset = [ant for ant in args.antennas.split(',') if len(ant)==1]
+
+	handler.setFourfitWrapper(args.fourfitwrapper)
+	handler.setFourfitControlFile(args.controlfile)
+	handler.setFreqGroup(args.freqgroup)
+	handler.setMaxNodes(int(args.maxnodes))
+	handler.setMachines(nodepool.machines())
+
+	jobs = handler.generateJobs(expt_path, antennaSubset)
+	handler.executeJobs(jobs)
+
+	# tidy up the terminal again, messed up by subprocess.Popen() before
+	p = subprocess.Popen(["/usr/bin/stty", "sane"], stdin=None, stdout=None, stderr=None, close_fds=True, shell=False)
+	p.communicate()

--- a/sites/MPIfR/hops/parFourfit.sh
+++ b/sites/MPIfR/hops/parFourfit.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# parFourfit.sh <fourfit control file> <scan1> [<scan2> <scan3> ...]
+#
+# Runs several fourfit instances in parallel, per baseline, for each
+# of the given scan(s). Fringe fits visibility data, excluding autos.
+# The scripts waits if more than 20 fourfit instances
+# are active on the computer.
+#
+# Example: parFourfit.sh cf_eht 1234/100-0243 1234/100-0517 1234/100-0525
+#
+# Optionally define env var FF_EXTRA_ARGS with fourfit arguments (e.g. EXTRA_ARGS=-PXL),
+# or FF_POST_ARGS with commands to append to fourfit (e.g. FF_POST_ARGS="set freqs a").
+
+set -m
+
+MAX_FF_INSTANCES=20
+
+if [ "$1" == "" ]; then
+    echo "Usage: parFourfit.sh <fourfit control file> <scan1> [<scan2> <scan3> ...]"
+fi
+
+for indir in "${@:2}"; do
+	echo $indir
+	rm -f ./$indir/*.lock
+
+	blines=()
+	for visfile in `ls -1 ./$indir/??..*`; do
+		bl=${visfile##*/}
+		bl=${bl%..*}
+		if [ "${bl:0:1}" == "${bl:1:1}" ]; then
+			# skip autocorrs and auto cross-pols?
+			continue  # to skip
+			#echo     # to keep
+		fi
+		blines+=("$bl")
+		# echo ${visfile##*/}  $bl
+	done
+
+	for bl in "${blines[@]}"; do
+		if compgen -G "./$indir/$bl..*" > /dev/null; then
+			solcount=`find ./$indir/ -name "$bl.[A-Z].*" | wc -l`
+			if [ "$solcount" != "4" ] && [ "$solcount" != "2" ]; then
+				echo "Interrupted fourfit in scan $indir baseline $bl, got $solcount instead of 4 solutions, redoing!"
+				rm -f ./$indir/$bl.?.*
+			fi
+			if compgen -G "./$indir/$bl.[A-Z].*" > /dev/null; then
+				echo "Scan $indir baseline $bl fourfit already done"
+			else
+				export cnt=`ps axuf | grep fourfit | wc -l`
+				while (( $cnt > $MAX_FF_INSTANCES )); do
+					echo "Waiting $indir baseline $bl : still too many ($cnt > 20) fourfit processes running..."
+					sleep 2
+					export cnt=`ps axuf | grep fourfit | wc -l`
+				done
+				echo "Scan $indir baseline $bl : fourfit"
+				echo "fourfit -m1 -c $1 -b$bl $FF_EXTRA_ARGS -u $indir $FF_POST_ARGS"
+				# fourfit -m1 -c $1 -b$bl $FF_EXTRA_ARGS -u $indir $FF_POST_ARGS &
+				fourfit -m1 -c $1 -b$bl $FF_EXTRA_ARGS -u $indir $FF_POST_ARGS 2>&1 | grep 'sbd\|SNR' &
+				err=$?
+				if [  "$err" != "0" ]; then
+					echo "Fourfit returned error $err! Stopping."
+					exit $err
+				fi
+			fi
+		fi
+	done
+	wait
+done

--- a/sites/MPIfR/hops/parFourfitSt.sh
+++ b/sites/MPIfR/hops/parFourfitSt.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# parFourfitSt.sh <fourfit control file> <station 1-letter ID> <scan1> [<scan2> <scan3> ...]
+#
+# Runs several fourfit instances in parallel, per baseline, for each
+# of the given scan(s). Fringe fits only the baselines to one particular station,
+# and excludes autocorrelations. The scripts waits if more than 20 fourfit instances
+# are active on the computer.
+#
+# Example: parFourfitSt.sh cf_eht A 1234/100-0243 1234/100-0517 1234/100-0525
+#
+# Optionally define env var FF_EXTRA_ARGS with fourfit arguments (e.g. EXTRA_ARGS=-PXL),
+# or FF_POST_ARGS with commands to append to fourfit (e.g. FF_POST_ARGS="set freqs a").
+
+set -m
+
+MAX_FF_INSTANCES=20
+
+if [ "$1" == "" ]; then
+	echo "Usage: parFourfitSt.sh <fourfit control file> <station 1-letter ID> <scan1> [<scan2> <scan3> ...]"
+fi
+
+for indir in "${@:3}"; do
+	echo $indir
+	rm -f ./$indir/*.lock
+
+        blines=()
+	for visfile in `ls -1 ./$indir/??..*`; do
+		bl=${visfile##*/}
+		bl=${bl%..*}
+		if [ "${bl:0:1}" == "${bl:1:1}" ]; then
+			# skip autocorrs and auto cross-pols?
+			continue  # to skip
+			#echo     # to keep
+		fi
+		if [ "${bl:0:1}" == "$2" ]; then
+			blines+=("$bl")
+		fi
+		if [ "${bl:1:1}" == "$2" ]; then
+			blines+=("$bl")
+		fi
+		# echo ${visfile##*/}  $bl
+	done
+
+	for bl in "${blines[@]}"; do
+		if compgen -G "./$indir/$bl..*" > /dev/null; then
+                        solcount=`find ./$indir/ -name "$bl.[A-Z].*" | wc -l`
+                        if [ "$solcount" != "4" ] && [ "$solcount" != "2" ]; then
+                                echo "Interrupted fourfit in scan $indir baseline $bl, got $solcount instead of 4 solutions, redoing!"
+                                rm -f ./$indir/$bl.?.*
+                        fi
+			if compgen -G "./$indir/$bl.[A-Z].*" > /dev/null; then
+				echo "Scan $indir baseline $bl fourfit already done"
+			else
+				export cnt=`ps axuf | grep fourfit | wc -l`
+				while (( $cnt > $MAX_FF_INSTANCES )); do
+					echo "Waiting $indir baseline $bl : still too many ($cnt > 20) fourfit processes running..."
+					sleep 2
+					export cnt=`ps axuf | grep fourfit | wc -l`
+				done
+				echo "Scan $indir baseline $bl : fourfit"
+				echo "fourfit -m1 -c $1 -b$bl $FF_EXTRA_ARGS -u $indir $FF_POST_ARGS"
+				# fourfit -m1 -c $1 -b$bl $FF_EXTRA_ARGS -u $indir $FF_POST_ARGS &
+				fourfit -m1 -c $1 -b$bl $FF_EXTRA_ARGS -u $indir $FF_POST_ARGS 2>&1 | grep 'sbd\|SNR' &
+				err=$?
+				if [  "$err" != "0" ]; then
+					echo "Fourfit returned error $err! Stopping."
+					exit $err
+				fi
+			fi
+		fi
+	done
+	wait
+done
+

--- a/sites/MPIfR/hops/parFourfit_auto.sh
+++ b/sites/MPIfR/hops/parFourfit_auto.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# parFourfit_auto.sh <fourfit control file> <scan1> [<scan2> <scan3> ...]
+#
+# Runs several fourfit instances in parallel, per baseline, for each
+# of the given scan(s). Autocorrelations are also fringe fitted.
+# The scripts waits if more than 20 fourfit instances
+# are active on the computer.
+#
+# Example: parFourfit_auto.sh cf_eht 1234/100-0243 1234/100-0517 1234/100-0525
+#
+# Optionally define env var FF_EXTRA_ARGS with fourfit arguments (e.g. EXTRA_ARGS=-PXL),
+# or FF_POST_ARGS with commands to append to fourfit (e.g. FF_POST_ARGS="set freqs a").
+
+set -m
+
+MAX_FF_INSTANCES=20
+
+if [ "$1" == "" ]; then
+    echo "Usage: parFourfit_auto.sh <fourfit control file> <scan1> [<scan2> <scan3> ...]"
+fi
+
+for indir in "${@:2}"; do
+	echo $indir
+	rm -f ./$indir/*.lock
+
+        blines=()
+	for visfile in `ls -1 ./$indir/??..*`; do
+		bl=${visfile##*/}
+		bl=${bl%..*}
+		if [ "${bl:0:1}" == "${bl:1:1}" ]; then
+			# skip autocorrs and auto cross-pols?
+			#continue  # to skip
+			echo     # to keep
+		fi
+		blines+=("$bl")
+		# echo ${visfile##*/}  $bl
+	done
+
+	for bl in "${blines[@]}"; do
+		if compgen -G "./$indir/$bl..*" > /dev/null; then
+			solcount=`find ./$indir/ -name "$bl.[A-Z].*" | wc -l`
+			if [ "$solcount" != "4" ] && [ "$solcount" != "2" ]; then
+				echo "Interrupted fourfit in scan $indir baseline $bl, got $solcount instead of 4 solutions, redoing!"
+				rm -f ./$indir/$bl.?.*
+			fi
+			if compgen -G "./$indir/$bl.[A-Z].*" > /dev/null; then
+				echo "Scan $indir baseline $bl fourfit already done"
+			else
+				export cnt=`ps axuf | grep fourfit | wc -l`
+				while (( $cnt > $MAX_FF_INSTANCES )); do
+					echo "Waiting $indir baseline $bl : still too many ($cnt > 20) fourfit processes running..."
+					sleep 2
+					export cnt=`ps axuf | grep fourfit | wc -l`
+				done
+				echo "Scan $indir baseline $bl : fourfit"
+				echo "fourfit -m1 -c $1 -b$bl -u $indir"
+				# fourfit -m1 -c $1 -b$bl $FF_EXTRA_ARGS -u $indir $FF_POST_ARGS &
+				fourfit -m1 -c $1 -b$bl $FF_EXTRA_ARGS -u $indir $FF_POST_ARGS 2>&1 | grep 'sbd\|SNR' &
+				err=$?
+				if [  "$err" != "0" ]; then
+					echo "Fourfit returned error $err! Stopping."
+					exit $err
+				fi
+			fi
+		fi
+	done
+	wait
+done

--- a/sites/MPIfR/mark6/Makefile.am
+++ b/sites/MPIfR/mark6/Makefile.am
@@ -1,0 +1,5 @@
+dist_bin_SCRIPTS = difxCheckMk6Modulepresence.py
+
+
+
+

--- a/sites/MPIfR/mark6/difxCheckMk6Modulepresence.py
+++ b/sites/MPIfR/mark6/difxCheckMk6Modulepresence.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python3
+'''
+Usage: difxCheckMk6Modulepresence.py <difxjob_0001.input> [<difxjob_0002.input> ...]
+
+Verifies that any files referenced by the DiFX jobs are indeed available.
+
+Files that match the pattern "/mark6-<nr>_fuse/<rest of path>.vdif" are
+considered to be part of Mark6 FUSE file based correlation. Accessibility
+of these Mark6 FUSE files is verified via SSH login and a file size check.
+
+Files that do not match the above pattern are considered to be e-transferred
+or copied Mark6 VDIF files that reside on the cluster file system. Accessibility
+in this case is verified by a file size check done on the local host.
+
+(C) 2020 Jan Wagner
+'''
+
+# TODO: add MSN-based lookup once libmark6gather & .input support Mark6 MSNs,
+#       the latter being critical (and ToDo...) to restrict the slots that libmark6gather collects data from
+
+import subprocess
+import sys
+
+def checkDatastreamAvailabilities(difxinputfile, checkLocalFiles=True):
+	'''
+	Collect all DATASTREAM entries from an .input file and check for availability of the
+	referenced Mark6 FUSE files via SSH to the respective hosts on the MPIfR VLBI cluster.
+	Optionally look up and check availability of non-Mark6 DATASTREAM files on BeeGFS.
+	'''
+
+	print ('Job %s : ' % (difxinputfile))
+
+	with open(difxinputfile, 'r') as f:
+
+		datastreamfiles = []
+		clusterfsfiles = []
+
+		for line in f:
+			if not 'FILE ' in line: continue
+			dstreamfile = line[20:].strip()
+			if not '/mark6-' in dstreamfile:
+				clusterfsfiles.append(dstreamfile)
+			else:
+				datastreamfiles.append(dstreamfile)
+
+		spawned = []
+		for dstreamfile in datastreamfiles:
+			host = dstreamfile[1:].split('/')[0]
+			host = host.split('_fuse')[0]
+			p = subprocess.Popen(["/usr/bin/ssh", host, "/usr/bin/du", "-h", dstreamfile], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+			spawned.append(p)
+
+		for i in range(len(datastreamfiles)):
+			(st,rc) = spawned[i].communicate()
+			dstreamfile = datastreamfiles[i]		
+			host = dstreamfile[1:].split('/')[0]
+			host = host.split('_fuse')[0]
+			# print (host, st)
+			if len(st)<1:
+				print('%s %s : MISSING' % (host,dstreamfile))
+			else:
+				print('%s %s : ok' % (host,dstreamfile))
+
+		if checkLocalFiles:
+			for clusterfsfile in clusterfsfiles:
+				p = subprocess.Popen(["/usr/bin/du", "-h", clusterfsfile], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+				(st,rc) = p.communicate()
+				if len(st)<1:
+					print('%s %s : MISSING' % ("localhost",clusterfsfile))
+				else:
+					print('%s %s : ok' % ("localhost",clusterfsfile))
+
+
+if __name__ == "__main__":
+
+	if '--help' in sys.argv or '-h' in sys.argv:
+		print(__doc__)
+		sys.exit(0)
+
+	for difxinputfile in sys.argv[1:]:
+		checkDatastreamAvailabilities(difxinputfile)

--- a/sites/MPIfR/oneoff/autoBands.py
+++ b/sites/MPIfR/oneoff/autoBands.py
@@ -466,12 +466,12 @@ class Autobands:
 				outputbands['flow'].append(foutstart)
 				outputbands['inputs'].append([[foutstart, self.outputbw]])
 				if self.verbosity > 1:
-					print ('Autobands::outputbands()    adding %.6f MHz bw from span %d @ %.6f MHz to fq %.6f MHz' % (self.outputbw,span,(foutstart-f0)*1e-6,foutstart))
+					print ('Autobands::outputbands()    case 1 adding %10.6f MHz bw from span %3d @ %10.6f MHz to fq %10.6f MHz' % (self.outputbw*1e-6,span,(foutstart-f0)*1e-6,foutstart*1e-6))
 				foutstart += self.outputbw
 
 			# Generate band in Case 2 : pieces of span(s) for a later complete band, patch over to next span(s)
 			bw_remain = f1 - foutstart
-			if (bw_remain) > 0 and self.detectedspans['continued'][span]:
+			if (bw_remain > 0) and self.detectedspans['continued'][span]:
 
 				# If overlap in rec bands at least at one antenna, may
 				# try a slight shift to begin at a more 'integer' MHz
@@ -493,7 +493,7 @@ class Autobands:
 					bw_utilized = min(bw_needed, bw_remain)
 					bw_needed -= bw_utilized
 					if self.verbosity > 1:
-						print ('Autobands::outputbands()    case 2 adding %10.6f MHz bw from span %d @ %.6f MHz to fq %10.6f MHz, remain %10.6f MHz' % (bw_utilized*1e-6,span,(slicestartfreq-f0)*1e-6,foutstart*1e-6,bw_needed*1e-6))
+						print ('Autobands::outputbands()    case 2 adding %10.6f MHz bw from span %3d @ %10.6f MHz to fq %10.6f MHz, remain %10.6f MHz' % (bw_utilized*1e-6,span,(slicestartfreq-f0)*1e-6,foutstart*1e-6,bw_needed*1e-6))
 					bw_inputs.append([slicestartfreq, bw_utilized])
 					slicestartfreq += bw_utilized
 					bw_remain = f1 - slicestartfreq

--- a/utilities/misc/geteop.pl
+++ b/utilities/misc/geteop.pl
@@ -16,26 +16,34 @@
 #===========================================================================
 # SVN properties (DO NOT CHANGE)
 #
-# $Id: geteop.pl 8985 2019-06-05 09:37:42Z JanWagner $
+# $Id: geteop.pl 9692 2020-09-01 14:15:38Z GeoffreyCrew $
 # $HeadURL: $
-# $LastChangedRevision: 8985 $
-# $Author: JanWagner $
-# $LastChangedDate: 2019-06-05 19:37:42 +1000 (Wed, 05 Jun 2019) $
+# $LastChangedRevision: 9692 $
+# $Author: GeoffreyCrew $
+# $LastChangedDate: 2020-09-02 00:15:38 +1000 (Wed, 02 Sep 2020) $
 #
 #============================================================================
 
 
+#$FINALS_SITE = "https://cddis.nasa.gov/archive";
+$FINALS_SITE = "ftp://gdc.cddis.eosdis.nasa.gov";
+$FINALS_PATH = "vlbi/gsfc/ancillary/solve_apriori";
 $FINALS_FILE = "usno_finals.erp";
-$FINALS_URL = "ftp://cddis.gsfc.nasa.gov/vlbi/gsfc/ancillary/solve_apriori/$FINALS_FILE";
+$FINALS_URL = "$FINALS_SITE/$FINALS_PATH/$FINALS_FILE";
+# previously:
+#$FINALS_URL = "ftp://cddis.gsfc.nasa.gov/vlbi/gsfc/ancillary/solve_apriori/$FINALS_FILE";
+
+# lip service to anon ftp security
+if (not exists $ENV{EMAIL_ADDR}) { &printUsage && die("\n"); }
 
 $eopCount = 0;
 $eopSuffix = "";
 
 if ($#ARGV < 1)
 {
-	&printUsage && die("\n");
+        &printUsage && die("\n");
 }
-	
+        
 $date = $ARGV[0];
 $numEop = $ARGV[1];
 if ($#ARGV == 2)
@@ -46,15 +54,15 @@ if ($#ARGV == 2)
 # split date into year and doy, calculate julian date
 if ($date =~ /(\d{4})-(\d+)/)
 {
-	$year = $1;
-	$doy = $2;
-	#print "year: $year $doy\n";
-	#$jdate = &calcJD($year,$doy, 23, 59, 59);
-	$jdate = &calcJD($year,$doy, 0, 0, 0);
+        $year = $1;
+        $doy = $2;
+        #print "year: $year $doy\n";
+        #$jdate = &calcJD($year,$doy, 23, 59, 59);
+        $jdate = &calcJD($year,$doy, 0, 0, 0);
 }
 else
 {
-	&printUsage && die("\n");
+        &printUsage && die("\n");
 }
 
 
@@ -72,16 +80,16 @@ elsif ($jdate > 2457203.5)
 # 30. Jun 2012
 elsif ($jdate > 2456109.5) 
 {
-	$TAIUTC = 35;
+        $TAIUTC = 35;
 }
 else
 {
-	$TAIUTC = 34;
+        $TAIUTC = 34;
 }
 
 # get the solution file
 system ("rm $FINALS_FILE");
-system ("wget $FINALS_URL");
+system ("curl -u anonymous:$ENV{EMAIL_ADDR} --ftp-ssl $FINALS_URL > $FINALS_FILE");
 sleep(1);
 
 open(INFILE, $FINALS_FILE) || die("Could not open file: $FINALS_FILE");
@@ -92,41 +100,41 @@ print OUTFILE  "\$EOP;\n";
 # parse the file
 while (<INFILE>)
 {
-	# skip comment lines
-	if ($_ =~ /#/)
-	{
-		next;
-	}
+        # skip comment lines
+        if ($_ =~ /#/)
+        {
+                next;
+        }
 
-	@fields = split(/\s+/, $_);
+        @fields = split(/\s+/, $_);
 
-	# check if first column contains a valid JD
-	if ($fields[0] =~ /\d+\.\d+/)
-	{	
+        # check if first column contains a valid JD
+        if ($fields[0] =~ /\d+\.\d+/)
+        {       
 
-		if (($fields[0] ge $jd) && ($eopCount < $numEop))
-		{
-			#print "$eopCount $numEop\n";
-			#print "0:$fields[0] 1:$fields[1] 2:$fields[2] 3:$fields[3]\n";
+                if (($fields[0] ge $jd) && ($eopCount < $numEop))
+                {
+                        #print "$eopCount $numEop\n";
+                        #print "0:$fields[0] 1:$fields[1] 2:$fields[2] 3:$fields[3]\n";
 
-			$xWobble = $fields[1] / 10.0;
-			$yWobble = $fields[2] /10.0;
-			$ut1utc  = $fields[3]  / 1e6 + $TAIUTC; 
-			$eopDay = $doy + $eopCount;
+                        $xWobble = $fields[1] / 10.0;
+                        $yWobble = $fields[2] /10.0;
+                        $ut1utc  = $fields[3]  / 1e6 + $TAIUTC; 
+                        $eopDay = $doy + $eopCount;
 
-			print OUTFILE "  def EOP$eopDay$eopSuffix;\n";
-			print OUTFILE "    TAI-UTC= $TAIUTC sec;\n";
-			print OUTFILE "    A1-TAI= 0 sec;\n";
-			print OUTFILE "    eop_ref_epoch=$year" . "y$eopDay" . "d;\n";
-			print OUTFILE "    num_eop_points=1;\n";
-			print OUTFILE "    eop_interval=24 hr;\n";
-			printf OUTFILE ("    ut1-utc  = %.6f sec;\n", $ut1utc);
-			printf OUTFILE ("    x_wobble = %.6f asec;\n", $xWobble);
-			printf OUTFILE ("    y_wobble = %.6f asec;\n", $yWobble);
-			print OUTFILE "  enddef;\n";
-			$eopCount += 1;
-		}
-	}
+                        print OUTFILE "  def EOP$eopDay$eopSuffix;\n";
+                        print OUTFILE "    TAI-UTC= $TAIUTC sec;\n";
+                        print OUTFILE "    A1-TAI= 0 sec;\n";
+                        print OUTFILE "    eop_ref_epoch=$year" . "y$eopDay" . "d;\n";
+                        print OUTFILE "    num_eop_points=1;\n";
+                        print OUTFILE "    eop_interval=24 hr;\n";
+                        printf OUTFILE ("    ut1-utc  = %.6f sec;\n", $ut1utc);
+                        printf OUTFILE ("    x_wobble = %.6f asec;\n", $xWobble);
+                        printf OUTFILE ("    y_wobble = %.6f asec;\n", $yWobble);
+                        print OUTFILE "  enddef;\n";
+                        $eopCount += 1;
+                }
+        }
 }
 
 print "Output written to EOP.txt\n";
@@ -160,16 +168,19 @@ sub printUsage
 {
         print "----------------------------------------------------------------------\n";
         print " Script to obtain EOP values from this URL:\n";
-	print " $FINALS_URL\n";
-	print " The EOPS are reformated to a format that can be used in the vex file \n";
+        print " $FINALS_URL\n";
+        print " The EOPS are reformated to a format that can be used in the vex file.\n";
         print "----------------------------------------------------------------------\n";
-        print "\nUsage: $0 yyyy-doy numEOP [EOPsuffix]\n\n";
+        print "\nUsage: EMAIL_ADDR=you\@domain $0 yyyy-doy numEOP [EOPsuffix]\n\n";
         print "yyyy-doy: the year and day-of-year of the first EOP value to obtain\n";
         print "numEOP:  the number of EOPs to get\n";
-        print "if provided, EOPsuffix will be appended to the EOP def name.\n";
-        print "output will be written to EOP.txt\n\n";
+        print "EOPsuffix: (optional) is appended to the EOP def name.\n";
+        print "output will be written to EOP.txt and the usno_finals.erp saved.\n\n";
         print "----------------------------------------------------------------------\n";
-	exit;
+        print "The script uses anonymous ftp which requires a valid user email which\n";
+        print "must be supplied via an environment variable EMAIL_ADDR\n";
+        print "----------------------------------------------------------------------\n";
+        exit;
 }
 
 

--- a/utilities/vis2screen/Makefile.am
+++ b/utilities/vis2screen/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = printDiFX
 dist_bin_SCRIPTS = diffDiFX.py diffDiFX2.py plotDiFX.py plotDiFXPCal.py fringeFindDiFX.py plotDynamicSpectrum.py snipDiFX.py \
-	plotResidualSpectrum.py polswapDiFX.py stripantennaDiFX.py printDiFX.py printDiFXInput.py replaceAntennaDiFX.py \
+	plotResidualSpectrum.py polswapDiFX.py stripantennaDiFX.py printDiFX.py printDiFXInput.py printDiFXPCal.py replaceAntennaDiFX.py \
 	removeNonzoomAutosDiFX.py removeZerovalAutoDiFX.py
 
 AM_CXXFLAGS = $(DIFXMESSAGE_CFLAGS) $(FXCORR_CFLAGS) $(IPP_CFLAGS) 

--- a/utilities/vis2screen/printDiFXInput.py
+++ b/utilities/vis2screen/printDiFXInput.py
@@ -242,7 +242,7 @@ def printDiFXInput(basename,opts,indent=2,version=2.6):
 				f = cfg.freqs[confq]
 				fstr = "%.6f MHz %3s at %.6f MHz" % (f.bandwidth, 'LSB' if f.lsb else 'USB', f.freq)
 				print((" "*2*indent) + "fq %3d bw %s" % (confq, fstr))
-
+		print((" "*1*indent) + "%d outputbands in total" % (nfreqs))
 		print("")
 
 if __name__ == "__main__":

--- a/utilities/vis2screen/printDiFXPCal.py
+++ b/utilities/vis2screen/printDiFXPCal.py
@@ -1,0 +1,83 @@
+#!/usr/bin/python
+"""
+printDiFXPCal.py version 1.0  Jan Wagner  20200813
+
+Usage: printDiFXPCal.py <output_xxx.difx/PCAL_id_timestamp> [datastream ID number] [toneIdx,[toneIdx,...]]
+
+Prints the content of the PCAL file in a tabular format,
+converting complex Re,Im data into polar Mag,Phase form.
+
+"""
+
+import math, sys
+import pandas as pd
+
+difxVersion = 240
+PC_column_dsId = 3
+PC_column_numChan = 4
+PC_column_numTones_ch0 = 5
+
+def cart2pol(re,im):
+	M = math.sqrt(re*re + im*im)
+	P = math.degrees(math.atan2(im,re))
+	return M,P
+
+def printTones(pcfile,datastreamId,toneIndices):
+	"""Loads selected (or all) PCal tones from a DiFX 2.4.x or later version PCAL file"""
+
+	df = pd.read_csv(pcfile, skiprows=5, header=None, delim_whitespace=True)
+
+	datastreamIDs = list(df[PC_column_dsId].unique())
+	if datastreamId is None:
+		datastreamId = datastreamIDs[0]
+		print('Showing tone(s) of datastream ID %d' % (datastreamId))
+	if datastreamId not in datastreamIDs:
+		print('Selected datastream IDs %d is not among the available IDs of %s' % (datastreamId, str(datastreamIDs)))
+		return
+
+	total_num_chan = 0
+	total_num_tones = 0
+
+	ds_dframe = df[df[PC_column_dsId] == datastreamId]
+	ds_num_channels = ds_dframe[PC_column_numChan].unique()
+	ds_tones_per_channel = ds_dframe.at[1, PC_column_numTones_ch0]
+
+	col = PC_column_numTones_ch0 + 1
+	rows_total = df.shape[0]
+
+	if toneIndices is None:
+		toneIndices = range(ds_num_channels*ds_tones_per_channel)
+
+	headings = []
+	for nn in toneIndices:
+		row = 1
+		col = PC_column_numTones_ch0 + 1 + 4*nn
+		freqMHz = float(ds_dframe.at[row, col])
+		bandCode = ds_dframe.at[row, col+1]
+		headings.append('%.1f%s' % (freqMHz, bandCode))
+	print('%5s %s' % ('', ''.join(['%16s' % h for h in headings])))
+
+	# while row in range(rows)
+	for row in range(1,rows_total):
+		print('%5d ' % (row)),
+		for nn in toneIndices:
+			col = PC_column_numTones_ch0 + 1 + 4*nn
+			re = float(ds_dframe.at[row, col+2])
+			im = float(ds_dframe.at[row, col+3])
+			mag,phase = cart2pol(re, im)
+			print('%7.2f %+7.2f' % (mag, phase)),
+		print('')
+
+if __name__ == '__main__':
+	if len(sys.argv) <= 1:
+		print(__doc__)
+	else:
+		pcalfile = sys.argv[1]
+		ds = None
+		tones = None
+		if len(sys.argv) > 2:
+			ds = int(sys.argv[2])
+		if len(sys.argv) > 3:
+			tones = [int(t) for t in sys.argv[3].split(',')]
+	
+		printTones(pcalfile, ds, tones)


### PR DESCRIPTION
r9705 | GeoffreyCrew | 2020-09-05 01:40:25 +1000 (Sat, 05 Sep 2020)
A clarification and accomodation of exhaustiveAutocorrs

r9704 | WalterBrisken | 2020-09-05 00:00:25 +1000 (Sat, 05 Sep 2020)
Add 2.6.2

r9703 | JanWagner | 2020-09-04 22:23:19 +1000 (Fri, 04 Sep 2020)
add --fgroup arg to distFourfit.py, update docu

r9702 | JanWagner | 2020-09-04 09:33:03 +1000 (Fri, 04 Sep 2020)
fix countdown printout in distFourfit.py

r9701 | JanWagner | 2020-09-04 09:26:07 +1000 (Fri, 04 Sep 2020)
fix distFourfit.py --maxnodes arg

r9700 | MichaelDutka | 2020-09-04 01:57:50 +1000 (Fri, 04 Sep 2020)
Adding site specific compilation and running instrcutions for Swinburn

r9699 | JanWagner | 2020-09-03 23:50:45 +1000 (Thu, 03 Sep 2020)
work around popen() mess-up of terminal in distFourfit.py

r9698 | JanWagner | 2020-09-03 23:17:49 +1000 (Thu, 03 Sep 2020)
tidy up distFourfit.py and add support for DIFX_MACHINES

r9697 | GeoffreyCrew | 2020-09-03 03:03:43 +1000 (Thu, 03 Sep 2020)
tag of 2.6 as 2.6.2

r9696 | GeoffreyCrew | 2020-09-03 01:03:33 +1000 (Thu, 03 Sep 2020)
final nits

r9695 | GeoffreyCrew | 2020-09-03 00:30:31 +1000 (Thu, 03 Sep 2020)
Various bits of cleanup (mostly help and commentary).

VEX2XML was not available in 2.5.3 and it may produce slightly
different results an option to disable that pending study was
introduced into the joblist script.

r9694 | GeoffreyCrew | 2020-09-02 00:50:16 +1000 (Wed, 02 Sep 2020)
clarified the instructions

r9693 | GeoffreyCrew | 2020-09-02 00:16:26 +1000 (Wed, 02 Sep 2020)
copy from trunk

r9692 | GeoffreyCrew | 2020-09-02 00:15:38 +1000 (Wed, 02 Sep 2020)
Modified to use curl --ftp-ssl per current CDDIS status.

r9691 | JanWagner | 2020-09-01 19:51:16 +1000 (Tue, 01 Sep 2020)
add copy of distFourfit.py script that distributes per-baseline fringe fits across cluster

r9690 | GeoffreyCrew | 2020-08-29 00:49:35 +1000 (Sat, 29 Aug 2020)
fixing version ids

r9689 | JanWagner | 2020-08-28 20:36:46 +1000 (Fri, 28 Aug 2020)
add new difxio API func isMixedPolMask() and use it in difx2fits, clarified the warning about 'unsupported' polmask to 'unsupported by FITS-IDI'

r9688 | JanWagner | 2020-08-28 20:18:09 +1000 (Fri, 28 Aug 2020)
fix difxio default <char>pol[] bug

r9687 | JanWagner | 2020-08-28 18:27:27 +1000 (Fri, 28 Aug 2020)
update docu of difxCheckMk6Modulepresence.py, change to python3, extend availability check also to etransferred files

r9686 | JanWagner | 2020-08-28 17:54:44 +1000 (Fri, 28 Aug 2020)
make install parFourfit scripts

r9685 | JanWagner | 2020-08-28 17:27:43 +1000 (Fri, 28 Aug 2020)
add copies of MPIfR simple parallelized fourfit'ting scripts

r9684 | JanWagner | 2020-08-28 00:39:26 +1000 (Fri, 28 Aug 2020)
d2m4 double NVRMAX to 8M, MAX_FPPAIRS to 10k, quadruple MAX_DFRQ to 800 to cope with EHT data and some multi narrow zoomband VGOS testing

r9683 | JanWagner | 2020-08-27 22:06:19 +1000 (Thu, 27 Aug 2020)
add copy of local MPIfR utility difxCheckMk6Modulepresence.py

r9682 | JanWagner | 2020-08-27 20:33:58 +1000 (Thu, 27 Aug 2020)
d260 Readme-Cycle5.txt make pristine

r9681 | JanWagner | 2020-08-27 19:56:47 +1000 (Thu, 27 Aug 2020)
printDiFXInput.py report the total count of mpifxcorr-outputted freqs

r9680 | JanWagner | 2020-08-27 19:55:02 +1000 (Thu, 27 Aug 2020)
autoBands.py minor reformatting of verbose output

r9679 | JanWagner | 2020-08-27 18:32:20 +1000 (Thu, 27 Aug 2020)
d260 doubled difx2mark4 NVRMAX to 8M because EHT e18e22 112-1002 does not convert

r9678 | JanWagner | 2020-08-26 21:05:13 +1000 (Wed, 26 Aug 2020)
make install printDiFXPCal.py

r9677 | JanWagner | 2020-08-26 21:01:27 +1000 (Wed, 26 Aug 2020) | 1 line
add printDiFXCal.py that pretty-prints mag,phase from PCAL files