### PR TITLE
Update to r9733

### DIFF
--- a/applications/difx2fits/ChangeLog
+++ b/applications/difx2fits/ChangeLog
@@ -1,3 +1,14 @@
+Commit 9???  2020.09.18
+
+* Support of a new options is added:
+  -A --all-pcal-tones. When applied, all phase calibration tones within 
+  recorded band are put in the output file overriding the tone selection
+  defined in difx input files.
+
+  Added statistics of printing skipped records.
+
+  Added additinal debugging statements with verbose > 3.
+
 Commit 9637  2020.07.30
 
 * Support of three new options is added:

--- a/applications/difx2fits/src/difx2fits.c
+++ b/applications/difx2fits/src/difx2fits.c
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2008-2019 by Walter Brisken & Helge Rottmann            *
+ *   Copyright (C) 2008-2020 by Walter Brisken & Helge Rottmann            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -19,11 +19,11 @@
 //===========================================================================
 // SVN properties (DO NOT CHANGE)
 //
-// $Id: difx2fits.c 9689 2020-08-28 10:36:46Z JanWagner $
+// $Id: difx2fits.c 9733 2020-09-21 20:48:05Z WalterBrisken $
 // $HeadURL: https://svn.atnf.csiro.au/difx/applications/difx2fits/trunk/src/difx2fits.c $
-// $LastChangedRevision: 9689 $
-// $Author: JanWagner $
-// $LastChangedDate: 2020-08-28 20:36:46 +1000 (Fri, 28 Aug 2020) $
+// $LastChangedRevision: 9733 $
+// $Author: WalterBrisken $
+// $LastChangedDate: 2020-09-22 06:48:05 +1000 (Tue, 22 Sep 2020) $
 //
 //============================================================================
 #include <stdio.h>
@@ -48,6 +48,7 @@ const double DefaultDifxPCalInterval = 30.0;	/* sec */
 const int    DefaultDifxAntPol       = 0;	
 const int    DefaultDifxPolXY2HV     = 0;	
 const int    DefaultDifxLocalDir     = 0;	
+const int    DefaultAllPcalTones     = 0;	
 
 /* FIXME: someday add option to specify EOP merge mode from command line */
 
@@ -156,6 +157,9 @@ static void usage(const char *pgm)
 	fprintf(stderr, "  --localdir\n");
 	fprintf(stderr, "  -l                  *.calc, *.im, and *.difx are sought in the same directory as *.input files\n");
 	fprintf(stderr, "\n");
+	fprintf(stderr, "  --all-pcal-tones\n");
+	fprintf(stderr, "  -A                  Extract all phase calibration tones\n");
+	fprintf(stderr, "\n");
 	fprintf(stderr, "  --primary-band <pb> Add PRIBAND keyword with value <pb> to FITS file\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "%s responds to the following environment variables:\n", program);
@@ -166,6 +170,9 @@ static void usage(const char *pgm)
 	fprintf(stderr, "    TCAL_PATH                 Path where switched power T_cal values are found.\n");
 	fprintf(stderr, "    TCAL_FILE                 Path to single specific T_cal file.\n");
 	fprintf(stderr, "    DIFX_MAX_SNIFFER_MEMORY   Max number of bytes to allow for sniffing.\n");
+	fprintf(stderr, "    DIFX2FITS_UVFITS_DUMP         Prints in stdout the ascii dump of records from the binary visilibity file. Warning: the output may be huge.\n");
+	fprintf(stderr, "    DIFX2FITS_UVFITS_DUMP_UTCMIN  Sets the minimum UTC time tag for the visibility dump. Units are seconds. Default is zero.\n");
+	fprintf(stderr, "    DIFX2FITS_UVFITS_DUMP_UTCMAX  Sets the maximum UTC time tag for the visibility dump. Units are seconds. Default is 86400.\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "PLEASE file all bug reports at http://svn.atnf.csiro.au/trac/difx .\n");
 	fprintf(stderr, "Include at a minimum the output of difx2fits with extra verbosity\n");
@@ -187,6 +194,7 @@ struct CommandLineOptions *newCommandLineOptions()
 	opts->antpol             = DefaultDifxAntPol; 
 	opts->polxy2hv           = DefaultDifxPolXY2HV; 
 	opts->localdir           = DefaultDifxLocalDir; 
+	opts->allpcaltones       = DefaultAllPcalTones;
 
 	return opts;
 }
@@ -356,6 +364,11 @@ struct CommandLineOptions *parseCommandLine(int argc, char **argv)
 			        strcmp(argv[i], "-l") == 0)
 			{
 				opts->localdir = 1;
+			}
+			else if(strcmp(argv[i], "--all-pcal-tones") == 0 ||
+			        strcmp(argv[i], "-A") == 0)
+			{
+				opts->allpcaltones = 1;
 			}
 			else if(i+1 < argc) /* one parameter arguments */
 			{
@@ -940,8 +953,9 @@ static DifxInput **loadDifxInputSet(const struct CommandLineOptions *opts)
 
 			return 0;
 		}
-                Dset[i]->AntPol   = opts->antpol;
-                Dset[i]->polxy2hv = opts->polxy2hv;
+                Dset[i]->AntPol       = opts->antpol;
+                Dset[i]->polxy2hv     = opts->polxy2hv;
+                Dset[i]->AllPcalTones = opts->allpcaltones;
 
 		Dset[i] = updateDifxInput(Dset[i], &opts->mergeOptions);
 

--- a/applications/difx2fits/src/difx2fits.h
+++ b/applications/difx2fits/src/difx2fits.h
@@ -75,6 +75,7 @@ struct CommandLineOptions
 	int  antpol;            /* if 1, then polarization is determined by antenna */        
 	int  polxy2hv;          /* if 1, then polarization X/Y is transformed to H/V */
 	int  localdir;          /* if 1, then *.calc, *.im, and *.difx are sought in the same directory as *.input files */
+	int  allpcaltones;      /* if 1, then all phase calibration tones are extactred */
 	DifxMergeOptions mergeOptions;
 };
 

--- a/applications/difx2fits/src/fitsPH.c
+++ b/applications/difx2fits/src/fitsPH.c
@@ -19,11 +19,11 @@
 //===========================================================================
 // SVN properties (DO NOT CHANGE)
 //
-// $Id: fitsPH.c 9649 2020-08-05 13:04:32Z JanWagner $
+// $Id: fitsPH.c 9730 2020-09-19 18:42:14Z WalterBrisken $
 // $HeadURL: https://svn.atnf.csiro.au/difx/applications/difx2fits/trunk/src/fitsPH.c $
-// $LastChangedRevision: 9649 $
-// $Author: JanWagner $
-// $LastChangedDate: 2020-08-05 23:04:32 +1000 (Wed, 05 Aug 2020) $
+// $LastChangedRevision: 9730 $
+// $Author: WalterBrisken $
+// $LastChangedDate: 2020-09-20 04:42:14 +1000 (Sun, 20 Sep 2020) $
 //
 //============================================================================
 
@@ -815,7 +815,7 @@ static int parseDifxPulseCal(const char *line,
 			/* set up pcal information for this recFreq (only up to nRecTones)*/
 			/* nRecTone is simply the number of tones that fall within the recorded band */
 			/* not all of them may be desired. */
-			nRecTone = DifxDatastreamGetPhasecalTones(toneFreq, dd, df, nt);
+			nRecTone = DifxDatastreamGetPhasecalTones(toneFreq, dd, df, nt, D->AllPcalTones);
 
 			nSkip = 0;				/* number of tones skipped because they weren't selected in the .input file */
 			if(nRecTone <= tone)
@@ -1294,7 +1294,7 @@ const DifxInput *DifxInput2FitsPH(const DifxInput *D,
 			int nDifxAntennaTones;
 			int freqSetId;
 			int originalDsIds[maxDatastreams];
-			int originalDsId = -1, currentDsId = -1;
+			int originalDsId = -1;
 			int nds;	// number of datastreams for this antenna for this job
 			int d;
 
@@ -1481,15 +1481,6 @@ const DifxInput *DifxInput2FitsPH(const DifxInput *D,
 							if(originalDsId < 0)
 							{
 								continue;	/* to next line in file */
-							}
-
-							if(D->job[jobId].datastreamIdRemap)
-							{
-								currentDsId = D->job[jobId].datastreamIdRemap[originalDsId];
-							}
-							else
-							{
-								currentDsId = originalDsId;
 							}
 
 							mjdRecord = time - refDay + (int)(D->mjdStart);

--- a/applications/difx2fits/src/fitsUV.c
+++ b/applications/difx2fits/src/fitsUV.c
@@ -19,11 +19,11 @@
 //===========================================================================
 // SVN properties (DO NOT CHANGE)
 //
-// $Id: fitsUV.c 9689 2020-08-28 10:36:46Z JanWagner $
+// $Id: fitsUV.c 9733 2020-09-21 20:48:05Z WalterBrisken $
 // $HeadURL: https://svn.atnf.csiro.au/difx/applications/difx2fits/trunk/src/fitsUV.c $
-// $LastChangedRevision: 9689 $
-// $Author: JanWagner $
-// $LastChangedDate: 2020-08-28 20:36:46 +1000 (Fri, 28 Aug 2020) $
+// $LastChangedRevision: 9733 $
+// $Author: WalterBrisken $
+// $LastChangedDate: 2020-09-22 06:48:05 +1000 (Tue, 22 Sep 2020) $
 //
 //============================================================================
 #include "fits.h"
@@ -368,22 +368,22 @@ DifxVis *newDifxVis(const DifxInput *D, int jobId, int pulsarBin, int phaseCentr
 			return 0;
 		}
 
-	      if(polMask & DIFXIO_POL_R)
-	      {
-		      dv->polStart = -1;
-	      }
-	      else if(polMask & DIFXIO_POL_L)
-	      {
-		      dv->polStart = -2;
-	      }
-	      else if(polMask & DIFXIO_POL_X)
-	      {
-		      dv->polStart = -5;
-	      }
-	      else /* must be YY only! who would do that? */
-	      {
-		      dv->polStart = -6;
-	      }
+		if(polMask & DIFXIO_POL_R)
+		{
+			dv->polStart = -1;
+		}
+		else if(polMask & DIFXIO_POL_L)
+		{
+			dv->polStart = -2;
+		}
+		else if(polMask & DIFXIO_POL_X)
+		{
+			dv->polStart = -5;
+		}
+		else /* must be YY only! who would do that? */
+		{
+			dv->polStart = -6;
+		}
 	}
 
 	/* room for input vis record: 3 for real, imag, weight */
@@ -469,65 +469,77 @@ void deleteDifxVis(DifxVis *dv)
 static int getPolProdId(const DifxVis *dv, const char *polPair)
 {
 	const char polSeq[8][4] = {"RR", "LL", "RL", "LR", "XX", "YY", "XY", "YX"};
-	const char pol1st[3][2] = {"R", "X", "H"};
-	const char pol2nd[3][2] = {"L", "Y", "V"};
-        int p, ind_1st, ind_2nd;
+	const char pol1st[3] = {'R', 'X', 'H'};
+	const char pol2nd[3] = {'L', 'Y', 'V'};
+	int p, ind_1st, ind_2nd;
 
-        if ( dv->D->AntPol == 0){
-	     for(p = 0; p < 8; ++p)
-	     {
-		     if(strncmp(polPair, polSeq[p], 2) == 0)
-		     {
-			     p = (p+1) + dv->polStart;
-			     
-			     if(p < 0 || p >= dv->D->nPolar)
-			     {
-				     return -1;
-			     }
-			     else
-			     {
-				     return p;
-			     }
-		     }
-             }
-	 } else 
-         {
+	if(dv->D->AntPol == 0)
+	{
+		for(p = 0; p < 8; ++p)
+		{
+			if(strncmp(polPair, polSeq[p], 2) == 0)
+			{
+				p = (p+1) + dv->polStart;
+
+				if(p < 0 || p >= dv->D->nPolar)
+				{
+					return -1;
+				}
+				else
+				{
+					return p;
+				}
+			}
+		}
+	}
+	else
+	{
 //
 // --------- Case of antenna-based polarizaiton (dv->D->AntPol == 0)
 // --------- Polarization order: A1A2  B1B2  A1B2  A2B1, where
 // --------- 1,2 are aNtenna indices and 
 // --------- A is the 1st polarization, B is the 2nd polarization
 //
-             ind_1st = 0;
-             ind_2nd = 0;
-	     p = -2; /* intialize with the error code */
-             for ( p = 0; p < 3; ++p ){
-                   if ( strncmp ( polPair,   pol1st[p], 1 ) == 0 ){ 
-                        ind_1st = 1;
-                   }
-                   if ( strncmp ( polPair+1, pol1st[p], 1 ) == 0 ){ 
-                        ind_2nd = 1;
-                   }
-                   if ( strncmp ( polPair,   pol2nd[p], 1 ) == 0 ){ 
-                        ind_1st = 2;
-                   }
-                   if ( strncmp ( polPair+1, pol2nd[p], 1 ) == 0 ){ 
-                        ind_2nd = 2;
-                   }
-             }
-             if ( ind_1st == 1 && ind_2nd == 1 ){
-                  p = 0;
-             }
-             if ( ind_1st == 2 && ind_2nd == 2 ){
-                  p = 1;
-             }
-             if ( ind_1st == 1 && ind_2nd == 2 ){
-                  p = 2;
-             }
-             if ( ind_1st == 2 && ind_2nd == 1 ){
-                  p = 3;
-             }
-	     return p;
+		ind_1st = 0;
+		ind_2nd = 0;
+		p = -2; /* intialize with the error code */
+		for(p = 0; p < 3; ++p)
+		{
+			if(polPair[0] == pol1st[p])
+			{
+				ind_1st = 1;
+			}
+			if(polPair[1] == pol1st[p])
+			{
+				ind_2nd = 1;
+			}
+			if(polPair[0] == pol2nd[p])
+			{
+				ind_1st = 2;
+			}
+			if(polPair[1] == pol2nd[p])
+			{
+				ind_2nd = 2;
+			}
+		}
+		if(ind_1st == 1 && ind_2nd == 1)
+		{
+			p = 0;
+		}
+		if(ind_1st == 2 && ind_2nd == 2)
+		{
+			p = 1;
+		}
+		if(ind_1st == 1 && ind_2nd == 2)
+		{
+			p = 2;
+		}
+		if(ind_1st == 2 && ind_2nd == 1)
+		{
+			p = 3;
+		}
+
+		return p;
 	}
 	
 	return -2;
@@ -558,8 +570,8 @@ static double evalPoly(const double *p, int n, double x)
 /* Auxilliary debugging routine for printing the contents of visilibity record */
 void UVfitsDump(const DifxVis *dv)
 {
-        int a1, a2, i,j,k,m;
-	int startChan, stopChan;
+	int a1, a2, i,j,k,m;
+	int startChan;
 	double utcmin, utcmax;
 	const double eps = 0.01;
 	char *str;
@@ -567,39 +579,52 @@ void UVfitsDump(const DifxVis *dv)
 
 	D = dv->D;
 	startChan = D->startChan;
-	stopChan = startChan + D->nOutChan*D->specAvg;
 
 	a1 = dv->record->baseline % 256 - 1;
 	a2 = dv->record->baseline / 256 - 1;
 
-        m=dv->nFreq*dv->D->nPolar;
+	m=dv->nFreq*dv->D->nPolar;
 
-        str = getenv("difx2fits_uvfits_dump_utcmin");
-	if ( str == NULL ){
-	     utcmin = 0.0;
-	} else { utcmin = atof(str); 
-        }
-        str = getenv("difx2fits_uvfits_dump_utcmax");
-	if ( str == NULL ){
-	     utcmin = 8640000;
-	} else { utcmax = atof(str); 
-        }
-        if ( dv->record->utc*86400.0 < utcmax + eps  && dv->record->utc*86400.0 > utcmin - eps){
-             printf ( "UV head utc: %9.7f ista %1d %1d fi %3d pol %1d start: %d stop: %d nfreq: %3d npol: %1d ncha: %4d nd: %8d wei %f scale: %g\n", 
-                      dv->record->utc*86400.0, a1, a2, dv->record->freqId1, dv->polId, 
-                      startChan, startChan, dv->nFreq, dv->D->nPolar, dv->D->nOutChan, 
-                      dv->nData, dv->record->data[0], dv->scale[a1]*dv->scale[a2] );
-            printf ( "UV head2 dv->D->nInChan %d dv->nComplex: %d dv->baseline: %d m= %3d \n", 
-                     dv->D->nInChan, dv->nComplex, dv->baseline, m );
-    	    for(i = 0; i < dv->nFreq; ++i){
-	        for(j = 0; j < dv->D->nOutChan; ++j){
-	            for(k = 0; k < dv->D->nPolar; ++k){
-                         printf ( "UV mjd: %5.0f utc: %9.3f sta: %1d %1d If: %2d Ic: %3d Ip: %1d vis: %14.7e, %14.7e \n", 
-                                   dv->record->jd - 2400000.5, dv->record->utc*86400.0, a1, a2, i, j, k, 
-                                   dv->record->data[m]/dv->scale[a1]/dv->scale[a2]/dv->recweight, 
-                                   -dv->record->data[m+1]/dv->scale[a1]/dv->scale[a2]/dv->recweight );
-                         m=m+2;
-        }}}}
+	str = getenv("DIFX2FITS_UVFITS_DUMP_UTCMIN");
+	if(!str)
+	{
+		utcmin = 0.0;
+	}
+	else
+	{
+		utcmin = atof(str);
+	}
+	str = getenv("DIFX2FITS_UVFITS_DUMP_UTCMAX");
+	if(!str)
+	{
+		utcmax = 8640000;
+	}
+	else
+	{
+		utcmax = atof(str);
+	}
+	if(dv->record->utc*86400.0 < utcmax + eps  && dv->record->utc*86400.0 > utcmin - eps)
+	{
+		printf("UV head utc: %9.7f ista %1d %1d fi %3d pol %1d start: %d stop: %d nfreq: %3d npol: %1d ncha: %4d nd: %8d wei %f scale: %g\n",
+			dv->record->utc*86400.0, a1, a2, dv->record->freqId1, dv->polId,
+			startChan, startChan, dv->nFreq, dv->D->nPolar, dv->D->nOutChan,
+			dv->nData, dv->record->data[0], dv->scale[a1]*dv->scale[a2]);
+		printf("UV head2 dv->D->nInChan %d dv->nComplex: %d dv->baseline: %d m= %3d \n", dv->D->nInChan, dv->nComplex, dv->baseline, m);
+		for(i = 0; i < dv->nFreq; ++i)
+		{
+			for(j = 0; j < dv->D->nOutChan; ++j)
+			{
+				for(k = 0; k < dv->D->nPolar; ++k)
+				{
+					printf("UV mjd: %5.0f utc: %9.3f sta: %1d %1d If: %2d Ic: %3d Ip: %1d vis: %14.7e, %14.7e \n",
+						dv->record->jd - 2400000.5, dv->record->utc*86400.0, a1, a2, i, j, k,
+						dv->record->data[m]/dv->scale[a1]/dv->scale[a2]/dv->recweight,
+						-dv->record->data[m+1]/dv->scale[a1]/dv->scale[a2]/dv->recweight);
+					m=m+2;
+				}
+			}
+		}
+	}
 }
 int DifxVisNewUVData(DifxVis *dv, int verbose, int skipextraautocorrs)
 {
@@ -634,7 +659,7 @@ int DifxVisNewUVData(DifxVis *dv, int verbose, int skipextraautocorrs)
 		{
 			return NEXT_FILE_ERROR;
 		}
-                v = fread(&(sync), sizeof(int), 1, dv->in);
+		v = fread(&(sync), sizeof(int), 1, dv->in);
 	}
 	++dv->nRec;
 
@@ -670,23 +695,23 @@ int DifxVisNewUVData(DifxVis *dv, int verbose, int skipextraautocorrs)
 			v += fread(&bin, sizeof(int), 1, dv->in);
 			v += fread(&weight, sizeof(double), 1, dv->in);
 			v += fread(uvw, sizeof(double), 3, dv->in);
-                        if(v != headerFields)
-                        {
+			if(v != headerFields)
+			{
 				fprintf(stderr, "Error parsing header: %d fields read; %d expected.\n", v, headerFields);
 
 				return HEADER_READ_ERROR;
-                        }
+			}
 			if(verbose > 3)
 			{
 				fprintf(stdout, "Read a vis from baseline %d\n", configBaselineId);
 			}
-                }
-                else //dunno what to do
-                {
-                        fprintf(stderr, "Error parsing header: got a sync of %x and version of %d\n", sync, binHeaderVersion);
-                        
+		}
+		else //dunno what to do
+		{
+			fprintf(stderr, "Error parsing header: got a sync of %x and version of %d\n", sync, binHeaderVersion);
+
 			return HEADER_READ_ERROR;
-                }
+		}
 	}
 	else
 	{
@@ -786,7 +811,7 @@ int DifxVisNewUVData(DifxVis *dv, int verbose, int skipextraautocorrs)
 	{
 		if(verbose > 2)
 		{
-			printf("Freq not used: freqId = %d.  Skipping record.\n", freqId);
+			printf("Freq not used: freqId= %d freqSetId= %d configId= %d, ind= %d.  Skipping record.\n", freqId, config->freqSetId, configId, dfs->freqId2IF[freqId] );
 		}
 
 		return SKIPPED_RECORD;
@@ -869,7 +894,7 @@ int DifxVisNewUVData(DifxVis *dv, int verbose, int skipextraautocorrs)
 			{
 				//printf("About to look at the actual im object\n");
 				im1 = scan->im[antId1][dv->phaseCentre + 1];
-	                        im2 = scan->im[antId2][dv->phaseCentre + 1];
+				im2 = scan->im[antId2][dv->phaseCentre + 1];
 				//printf("Got the im structures - they are %p and %p\n", im1, im2);
 				if(!(im1 && im2))
 				{
@@ -933,21 +958,21 @@ int DifxVisNewUVData(DifxVis *dv, int verbose, int skipextraautocorrs)
 	
 	if(dv->polId < 0 || dv->polId >= dv->D->nPolar)
 	{
-                if(configBaselineId % 257 == 0 && skipextraautocorrs)
-                {
-                        // Silently ignore e.g. LL autocorrelations in an RR-only correlation
-                        return SKIPPED_RECORD;
-                }
-                else
-                {
-		        fprintf(stderr, "Baseline %d: Parameter problem: polId should be in [0, %d), was %d; polPair was '%s'\n", dv->baseline, dv->D->nPolar, dv->polId, polPair);
-                        if(configBaselineId % 257 == 0) //Tell the user how to get around this problem
-                        {
-                            fprintf(stderr, "This polarisation error was generated by an autocorrelation.  To skip autocorrelations which don't correspond to any computed cross-correlations, re-run difx2fits with --skip-extra-autocorrs\n");
-                        }
+		if(configBaselineId % 257 == 0 && skipextraautocorrs)
+		{
+			// Silently ignore e.g. LL autocorrelations in an RR-only correlation
+			return SKIPPED_RECORD;
+		}
+		else
+		{
+			fprintf(stderr, "Baseline %d: Parameter problem: polId should be in [0, %d), was %d; polPair was '%s'\n", dv->baseline, dv->D->nPolar, dv->polId, polPair);
+			if(configBaselineId % 257 == 0) //Tell the user how to get around this problem
+			{
+				fprintf(stderr, "This polarisation error was generated by an autocorrelation.  To skip autocorrelations which don't correspond to any computed cross-correlations, re-run difx2fits with --skip-extra-autocorrs\n");
+			}
 
-		        return POL_ID_ERROR;
-                }
+			return POL_ID_ERROR;
+		}
 	}
 
 	/* don't read weighted data into unweighted slot */
@@ -1191,13 +1216,15 @@ static int storevis(DifxVis *dv)
 	return 0;
 }
 
-static int readvisrecord(DifxVis *dv, int verbose, int skipextraautocorrs)
+static int readvisrecord(DifxVis *dv, int verbose, int skipextraautocorrs, int* nSkipped_recs )
 {
 	/* blank array */
 	memset(dv->weight, 0, dv->nFreq*dv->D->nPolar*sizeof(float));
 	memset(dv->data, 0, dv->nData*sizeof(float));
 
 	dv->changed = 0;
+
+        *nSkipped_recs = 0;
 
 	while(dv->changed == 0 || dv->changed == SKIPPED_RECORD)
 	{
@@ -1213,6 +1240,10 @@ static int readvisrecord(DifxVis *dv, int verbose, int skipextraautocorrs)
 		if(dv->changed == HEADER_READ_ERROR)
 		{
 			return -1;
+		}
+		if(dv->changed == SKIPPED_RECORD)
+		{
+			(*nSkipped_recs)++;
 		}
 	}
 
@@ -1240,6 +1271,8 @@ const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fi
 	int nTrans = 0;
 	int nWritten = 0;
 	int nOld = 0;
+	int nSkipped = 0;
+	int nSkipped_recs;
 	double mjd, bestmjd;
 	DifxVis **dvs;
 	DifxVis *dv;
@@ -1461,7 +1494,7 @@ const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fi
 		{
 			fprintf(stdout, "Priming, dv=%d/%d\n", dvId, nDifxVis);
 		}
-		readvisrecord(dvs[dvId], opts->verbose, opts->skipExtraAutocorrs);
+		readvisrecord(dvs[dvId], opts->verbose, opts->skipExtraAutocorrs, &nSkipped_recs);
 		if(opts->verbose > 3)
 		{
 			fprintf(stdout, "Done priming DifxVis objects\n");
@@ -1531,12 +1564,15 @@ const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fi
 			{
 				feedJobMatrix(jobMatrix, dv->record, dv->jobId);
 			}
-                        str = getenv("difx2fits_uvfits_dump");
-			if ( str != NULL ){
-                             if ( strncpy(str,"yes",4) ){
-                                  UVfitsDump( dv ); 
-                             }
-                        }
+
+			str = getenv("DIFX2FITS_UVFITS_DUMP");
+			if(str)
+			{
+				if(strncpy(str, "yes", 4))
+				{
+					UVfitsDump(dv);
+				}
+			}
 #ifndef WORDS_BIGENDIAN
 			FitsBinRowByteSwap(columns, nColumn, dv->record);
 #endif
@@ -1552,6 +1588,10 @@ const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fi
 
 			fitsWriteBinRow(out, (char *)dv->record);
 			++nWritten;
+		}
+		if(dv->changed == SKIPPED_RECORD)
+		{
+			++nSkipped;
 		}
 		if(dv->changed < 0)
 		{
@@ -1575,8 +1615,13 @@ const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fi
 				return 0;
 			}
 
-			readvisrecord(dv, opts->verbose, opts->skipExtraAutocorrs);
+			readvisrecord(dv, opts->verbose, opts->skipExtraAutocorrs, &nSkipped_recs);
+			nSkipped = nSkipped + nSkipped_recs;
 		}
+	}
+	if(opts->verbose > 2)
+	{
+		printf("      dv->D->nConfig= %d\n", dv->D->nConfig);
 	}
 
 	printf("      %d invalid records dropped\n", nInvalid);
@@ -1585,6 +1630,7 @@ const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fi
 	printf("      %d negative weight records\n", nNegWeight);
 	printf("      %d scan boundary records dropped\n", nTrans);
 	printf("      %d out-of-time-range records dropped\n", nOld);
+	printf("      %d records skipped\n", nSkipped);
 	printf("      %d records written\n", nWritten);
 	printf("      FITS MJD range: %12.6f to %12.6f\n", firstMJD, lastMJD);
 	if(opts->verbose > 1)

--- a/applications/mk5daemon/src/mk5daemon.cpp
+++ b/applications/mk5daemon/src/mk5daemon.cpp
@@ -19,11 +19,11 @@
 /*===========================================================================
  * SVN properties (DO NOT CHANGE)
  *
- * $Id: mk5daemon.cpp 9721 2020-09-11 08:18:02Z HelgeRottmann $
+ * $Id: mk5daemon.cpp 9732 2020-09-21 14:43:48Z GeoffreyCrew $
  * $HeadURL: https://svn.atnf.csiro.au/difx/applications/mk5daemon/trunk/src/mk5daemon.cpp $
- * $LastChangedRevision: 9721 $
- * $Author: HelgeRottmann $
- * $LastChangedDate: 2020-09-11 18:18:02 +1000 (Fri, 11 Sep 2020) $
+ * $LastChangedRevision: 9732 $
+ * $Author: GeoffreyCrew $
+ * $LastChangedDate: 2020-09-22 00:43:48 +1000 (Tue, 22 Sep 2020) $
  *
  *==========================================================================*/
 
@@ -505,8 +505,11 @@ void deleteMk5Daemon(Mk5Daemon *D)
 	{
                 // unmount all mark6 disks
                 if (D->isMk6)
+#ifdef HAS_MARK6META
                     D->mark6->cleanUp();
-
+#else
+                fprintf(stderr, "Mark6 cleanup requested, but not linked.\n");
+#endif
 		D->dieNow = 1;
 		Mk5Daemon_stopMonitor(D);
 		Mk5Daemon_stopVSIS(D);
@@ -1108,11 +1111,11 @@ int main(int argc, char **argv)
     int highSock;
     int v;
     int halfSwapMonInterval;
-    int halfLoadMonInterval;
     int pid;
     int status;
 
 #ifdef HAVE_XLRAPI_H
+    int halfLoadMonInterval;
     time_t firstTime;
     int ok = 0;	/* FIXME: combine with D->ready? */
     int justStarted = 1;
@@ -1124,7 +1127,7 @@ int main(int argc, char **argv)
             isMk5 = 0;
     }
 #else
-    int isMk5 = 0;
+    // int isMk5 = 0;
 #endif
 
     try
@@ -1226,9 +1229,9 @@ int main(int argc, char **argv)
 	lastTime = time(0);
 
 	halfSwapMonInterval = D->swapMonInterval/2 + 3;
-	halfLoadMonInterval = D->loadMonInterval/2;
 
 #ifdef HAVE_XLRAPI_H
+	halfLoadMonInterval = D->loadMonInterval/2;
 	firstTime = lastTime;
 
 	v = initWatchdog();

--- a/libraries/difxio/difxio/difx_datastream.c
+++ b/libraries/difxio/difxio/difx_datastream.c
@@ -19,11 +19,11 @@
 //===========================================================================
 // SVN properties (DO NOT CHANGE)
 //
-// $Id: difx_datastream.c 9636 2020-07-31 02:13:03Z LeonidPetrov $
+// $Id: difx_datastream.c 9728 2020-09-19 02:40:01Z LeonidPetrov $
 // $HeadURL: https://svn.atnf.csiro.au/difx/libraries/difxio/trunk/difxio/difx_datastream.c $
-// $LastChangedRevision: 9636 $
+// $LastChangedRevision: 9728 $
 // $Author: LeonidPetrov $
-// $LastChangedDate: 2020-07-31 12:13:03 +1000 (Fri, 31 Jul 2020) $
+// $LastChangedDate: 2020-09-19 12:40:01 +1000 (Sat, 19 Sep 2020) $
 //
 //============================================================================
 
@@ -372,13 +372,13 @@ void DifxDatastreamCalculatePhasecalTones(DifxDatastream *dd, const DifxFreq *df
  * For LSBs the flags in toneFreq[] are returned descending in frequency.
  * This is the order in which they are written out by mpifxcorr in the pcal file.
  *
- * Return the number of tones extracted by DiFX.
+ * Return the number of tones extracted by DiFX. Not all these tones may be exporrted to FITS-IDI
  */
-int DifxDatastreamGetPhasecalTones(double *toneFreq, const DifxDatastream *dd, const DifxFreq *df, int maxCount)
+int DifxDatastreamGetPhasecalTones(double *toneFreq, const DifxDatastream *dd, const DifxFreq *df, int maxCount, int AllPcalTones)
 {
 	double lowest, highest;
 	int nRecTone=0;
-	int t;
+	int i, j, t;
 
 	for(t = 0; t < maxCount; ++t)
 	{
@@ -393,26 +393,41 @@ int DifxDatastreamGetPhasecalTones(double *toneFreq, const DifxDatastream *dd, c
 
 	/* Get number of tones, and lowest/highest in-band non-DC tone frequencies */
 	nRecTone = DifxDatastreamGetPhasecalRange(dd, df, &lowest, &highest);
-
 	/* Fill in the tone frequencies and on/off values */
-	for(t = 0; t < df->nTone; ++t)
-	{
-		int i, j;
-
-		i = df->tone[t];
-		if(df->sideband == 'U')
+	if ( AllPcalTones == 0 ){
+	     /* Use the phase cal tones specified in the difx input files */
+	     for(t = 0; t < df->nTone; ++t)
+	     {
+     		i = df->tone[t];
+		     if(df->sideband == 'U')
+		     {
+			     j = i;
+		     }
+		     else
+		     {
+			     j = nRecTone - 1 - i;	/* reverse order of LSB tones */
+		     }
+		     if(j >= 0 && j < maxCount)
+		     {
+			     toneFreq[j] = lowest + i*dd->phaseCalIntervalMHz;
+		     }
+	     }
+        } 
+        else
+        {
+	     /* Use all the phase cal tones regardless what is in the difx input files */
+	     for( t = 0; t < nRecTone; ++t)
+	     {
+		if ( df->sideband == 'U')
 		{
-			j = i;
+		    toneFreq[t] = lowest  + t*dd->phaseCalIntervalMHz;
 		}
 		else
 		{
-			j = nRecTone - 1 - i;	/* reverse order of LSB tones */
+		    toneFreq[t] = highest - t*dd->phaseCalIntervalMHz;
 		}
-		if(j >= 0 && j < maxCount)
-		{
-			toneFreq[j] = lowest + i*dd->phaseCalIntervalMHz;
-		}
-	}
+	     }
+        } 
 
 	return nRecTone;
 }

--- a/libraries/difxio/difxio/difx_freq.c
+++ b/libraries/difxio/difxio/difx_freq.c
@@ -19,11 +19,11 @@
 //===========================================================================
 // SVN properties (DO NOT CHANGE)
 //
-// $Id: difx_freq.c 9424 2020-02-06 09:00:19Z JanWagner $
+// $Id: difx_freq.c 9728 2020-09-19 02:40:01Z LeonidPetrov $
 // $HeadURL: https://svn.atnf.csiro.au/difx/libraries/difxio/trunk/difxio/difx_freq.c $
-// $LastChangedRevision: 9424 $
-// $Author: JanWagner $
-// $LastChangedDate: 2020-02-06 20:00:19 +1100 (Thu, 06 Feb 2020) $
+// $LastChangedRevision: 9728 $
+// $Author: LeonidPetrov $
+// $LastChangedDate: 2020-09-19 12:40:01 +1000 (Sat, 19 Sep 2020) $
 //
 //============================================================================
 
@@ -165,23 +165,41 @@ int isSameDifxFreqToneSet(const DifxFreq *df1, const DifxFreq *df2)
 	return 1;
 }
 
-int isSameDifxFreq(const DifxFreq *df1, const DifxFreq *df2)
+int isSameDifxFreq(const DifxFreq *df1, const DifxFreq *df2, int AllPcalTones )
 {
-	if(df1->freq       == df2->freq &&
-	   df1->bw         == df2->bw   &&
-	   df1->sideband   == df2->sideband &&
-	   df1->specAvg    == df2->specAvg &&
-	   df1->nChan      == df2->nChan &&
-	   df1->overSamp   == df2->overSamp &&
-	   df1->decimation == df2->decimation &&
-	   isSameDifxFreqToneSet(df1, df2) )
-	{
-		return 1;
-	}
-	else
-	{
-		return 0;
-	}
+        if ( AllPcalTones == 0 ){
+	     if(df1->freq       == df2->freq &&
+	        df1->bw         == df2->bw   &&
+	        df1->sideband   == df2->sideband &&
+	        df1->specAvg    == df2->specAvg &&
+	        df1->nChan      == df2->nChan &&
+	        df1->overSamp   == df2->overSamp &&
+	        df1->decimation == df2->decimation &&
+	        isSameDifxFreqToneSet(df1, df2) )
+	     {
+		     return 1;
+	     }
+	     else
+	     {
+		     return 0;
+	     }
+        }
+        else {
+	     if(df1->freq       == df2->freq &&
+	        df1->bw         == df2->bw   &&
+	        df1->sideband   == df2->sideband &&
+	        df1->specAvg    == df2->specAvg &&
+	        df1->nChan      == df2->nChan &&
+	        df1->overSamp   == df2->overSamp &&
+	        df1->decimation == df2->decimation )
+	     {
+		     return 1;
+	     }
+	     else
+	     {
+		     return 0;
+	     }
+        }
 }
 
 int isDifxIFInsideDifxFreq(const DifxIF *di, const DifxFreq *df)
@@ -444,7 +462,7 @@ int simplifyDifxFreqs(DifxInput *D)
 
 		for(f1 = 0; f1 < f; ++f1)
 		{
-			if(isSameDifxFreq(D->freq+f, D->freq+f1))
+			if(isSameDifxFreq(D->freq+f, D->freq+f1, D->AllPcalTones) )
 			{
 				break;
 			}
@@ -523,7 +541,7 @@ int simplifyDifxFreqs(DifxInput *D)
 /* @brief merge two DifxFreq tables into an new one.  freqIdRemap will contain the
  * mapping from df2's old freq entries to that of the merged set
  */
-DifxFreq *mergeDifxFreqArrays(const DifxFreq *df1, int ndf1, const DifxFreq *df2, int ndf2, int *freqIdRemap, int *ndf)
+DifxFreq *mergeDifxFreqArrays(const DifxFreq *df1, int ndf1, const DifxFreq *df2, int ndf2, int *freqIdRemap, int *ndf, int AllPcalTones)
 {
 	DifxFreq *df;
 	int i, j;
@@ -535,7 +553,7 @@ DifxFreq *mergeDifxFreqArrays(const DifxFreq *df1, int ndf1, const DifxFreq *df2
 	{
 		for(i = 0; i < ndf1; ++i)
 		{
-			if(isSameDifxFreq(df1 + i, df2 + j))
+			if(isSameDifxFreq(df1 + i, df2 + j, AllPcalTones))
 			{
 				freqIdRemap[j] = i;
 				break;

--- a/libraries/difxio/difxio/difx_input.h
+++ b/libraries/difxio/difxio/difx_input.h
@@ -19,11 +19,11 @@
 //===========================================================================
 // SVN properties (DO NOT CHANGE)
 //
-// $Id: difx_input.h 9689 2020-08-28 10:36:46Z JanWagner $
+// $Id: difx_input.h 9729 2020-09-19 17:57:50Z WalterBrisken $
 // $HeadURL: https://svn.atnf.csiro.au/difx/libraries/difxio/trunk/difxio/difx_input.h $
-// $LastChangedRevision: 9689 $
-// $Author: JanWagner $
-// $LastChangedDate: 2020-08-28 20:36:46 +1000 (Fri, 28 Aug 2020) $
+// $LastChangedRevision: 9729 $
+// $Author: WalterBrisken $
+// $LastChangedDate: 2020-09-20 03:57:50 +1000 (Sun, 20 Sep 2020) $
 //
 //============================================================================
 
@@ -286,16 +286,14 @@ typedef struct
 	enum ClockMergeMode clockMergeMode;
 } DifxMergeOptions;
 
-
-
 /* Straight from DiFX frequency table */
 typedef struct
 {
 	double freq;		/* (MHz) */
 	double bw;		/* (MHz) */
 	char sideband;		/* U or L -- net sideband */
-        int nChan;
-	int specAvg;            /* This is averaging within mpifxcorr  */
+	int nChan;
+	int specAvg;		/* This is averaging within mpifxcorr  */
 	int overSamp;
 	int decimation;
 	int nTone;		/* Number of pulse cal tones */
@@ -310,7 +308,7 @@ typedef struct
 	double bw;		/* (MHz) */
 	char sideband;		/* U or L -- net sideband */
 	int nPol;		/* 1 or 2 */
-	char pol[2];		/* polarization codes (one per nPol) : L R X Y, H or V. */
+	char pol[2];		/* polarization codes (one per nPol) : L R X Y H or V. */
 	char rxName[DIFXIO_RX_NAME_LENGTH];
 } DifxIF;
 
@@ -420,10 +418,10 @@ typedef struct
 	char dataFormat[DIFXIO_FORMAT_LENGTH];   /* e.g., VLBA, MKIV, ... */
 
 	enum SamplingType dataSampling; /* REAL or COMPLEX */
-	int nFile;              /* number of files */
-        char **file;            /* list of files to correlate (if not VSN) */
+	int nFile;		/* number of files */
+	char **file;		/* list of files to correlate (if not VSN) */
 	char networkPort[DIFXIO_ETH_DEV_SIZE]; /* eVLBI port for this datastream */
-	int windowSize;         /* eVLBI TCP window size */
+	int windowSize;		/* eVLBI TCP window size */
 	int quantBits;		/* quantization bits */
 	int dataFrameSize;	/* (bytes) size of formatted data frame */
 	enum DataSource dataSource;	/* MODULE, FILE, NET, other? */
@@ -431,15 +429,15 @@ typedef struct
 	float phaseCalIntervalMHz;/* 0 if no phase cal extraction, otherwise extract every tone and retain tones selected elsewhere */
 	float phaseCalBaseMHz;	/* propagated from VEX1.5 but unused for now */
 	int tcalFrequency;	/* 0 if no switched power extraction to be done.  =80 for VLBA */
-	int nRecTone;     /* number of pcal tones in the *recorded* baseband*/
-	int *recToneFreq; /* Frequency of each pcal tone in the *recorded* baseband in MHz */
-	int *recToneOut;  /* bool Recorded pcal written out?*/
+	int nRecTone;		/* number of pcal tones in the *recorded* baseband*/
+	int *recToneFreq;	/* Frequency of each pcal tone in the *recorded* baseband in MHz */
+	int *recToneOut;	/* bool Recorded pcal written out?*/
 
 	double *clockOffset;	/* (us) [freq] */
 	double *clockOffsetDelta; /* (us) [freq] */
 	double *phaseOffset;	/* (degrees) [freq] */
 	double *freqOffset;	/* Freq offsets for each frequency in Hz */
-	char pol[2];            /* polarization codes (one per nPol) : L R X Y, H or V. */
+	char pol[2];		/* polarization codes (one per nPol) : L R X Y, H or V. */
 	
 	int nRecFreq;		/* number of freqs recorded in this datastream */
 	int nRecBand;		/* number of base band channels recorded */
@@ -448,7 +446,7 @@ typedef struct
 	int *recBandFreqId;	/* [recband] index to recFreqId[] */
 	char *recBandPolName;	/* [recband] Polarization name (R, L, X or Y) */
 
-        int nZoomFreq;		/* number of "zoom" freqs (within recorded freqs) for this datastream */
+	int nZoomFreq;		/* number of "zoom" freqs (within recorded freqs) for this datastream */
 	int nZoomBand;		/* number of zoom subbands */
 	int *nZoomPol;		/* [zoomfreq] */
 	int *zoomFreqId;	/* [zoomfreq] index to DifxFreq table */
@@ -554,17 +552,17 @@ typedef struct
 	double mjdStart;			/* (day) */
 	double mjdEnd;				/* (day) */
 	int startSeconds;			/* Since model reference (top of calc file) */
-	int durSeconds; 			/* Duration of the scan */
-        char identifier[DIFXIO_NAME_LENGTH];	/* Usually a zero-based number */
+	int durSeconds;				/* Duration of the scan */
+	char identifier[DIFXIO_NAME_LENGTH];	/* Usually a zero-based number */
 	char obsModeName[DIFXIO_NAME_LENGTH];	/* Identifying the "mode" of observation */
 	int maxNSBetweenUVShifts;		/* Maximum interval until data must be shifted/averaged */
 	int maxNSBetweenACAvg;			/* Maximum interval until autocorrelations are sent/averaged */
-        int pointingCentreSrc;  		/* index to source array */
-        int nPhaseCentres;      		/* Number of correlation centres */
-        int phsCentreSrcs[MAX_PHS_CENTRES]; 	/* indices to source array */
+	int pointingCentreSrc;			/* index to source array */
+	int nPhaseCentres;			/* Number of correlation centres */
+	int phsCentreSrcs[MAX_PHS_CENTRES];	/* indices to source array */
 	int orgjobPhsCentreSrcs[MAX_PHS_CENTRES];/* indices to the source array from the original (pre-merged) job */
 	int jobId;				/* 0, 1, ... nJob-1 */
-        int configId;           		/* to determine freqId */
+	int configId;				/* to determine freqId */
 	int nAntenna;
 	int nPoly;
 	DifxPolyModel ***im;	/* indexed by [ant][src][poly] */
@@ -684,8 +682,9 @@ typedef struct
 
 	int nIF;		/* maximum num IF across configs */
 	int nPol;		/* maximum num pol across configs */
-        int AntPol;             /* 1 for antenna defined polarizations */
-	int polxy2hv;           /* if 1, then polarization X/Y is transformed to H/V */
+	int AntPol;		/* 1 for antenna defined polarizations */
+	int polxy2hv;		/* if 1, then polarization X/Y is transformed to H/V */
+	int AllPcalTones;	/* if 1, then all phase calibration tomes are extracted */
 	int doPolar;		/* 0 if not, 1 if so */
 	int nPolar;		/* nPol*(doPolar+1) */
 				/* 1 for single pol obs */
@@ -695,8 +694,8 @@ typedef struct
 	int quantBits;		/* 0 if different in configs; or 1 or 2 */
 	char polPair[4];	/* "  " if different in configs */
 	int dataBufferFactor;
-        int nDataSegments;
-        enum OutputFormatType outputFormat;
+	int nDataSegments;
+	enum OutputFormatType outputFormat;
 
 	int nCore;		/* from the .threads file, or zero if no file */
 	int *nThread;		/* [coreId]: how many threads to use on each core */
@@ -740,11 +739,11 @@ void deleteDifxFreqArray(DifxFreq *df, int nFreq);
 void printDifxFreq(const DifxFreq *df);
 void fprintDifxFreq(FILE *fp, const DifxFreq *df);
 int isSameDifxFreqToneSet(const DifxFreq *df1, const DifxFreq *df2);
-int isSameDifxFreq(const DifxFreq *df1, const DifxFreq *df2);
+int isSameDifxFreq(const DifxFreq *df1, const DifxFreq *df2, int AllPcalTones);
 int isDifxIFInsideDifxFreq(const DifxIF *di, const DifxFreq *df);
 void copyDifxFreq(DifxFreq *dest, const DifxFreq *src);
 int simplifyDifxFreqs(DifxInput *D);
-DifxFreq *mergeDifxFreqArrays(const DifxFreq *df1, int ndf1, const DifxFreq *df2, int ndf2, int *freqIdRemap, int *ndf);
+DifxFreq *mergeDifxFreqArrays(const DifxFreq *df1, int ndf1, const DifxFreq *df2, int ndf2, int *freqIdRemap, int *ndf, int AllPcalTones);
 int writeDifxFreqArray(FILE *out, int nFreq, const DifxFreq *df);
 
 /* DifxFreqSet functions */
@@ -790,7 +789,7 @@ void DifxDatastreamAllocZoomBands(DifxDatastream *dd, int nZoomBand);
 void DifxDatastreamAllocPhasecalTones(DifxDatastream *dd, int nTones);
 int DifxDatastreamGetPhasecalRange(const DifxDatastream *dd, const DifxFreq *df, double* lowest, double* highest);
 void DifxDatastreamCalculatePhasecalTones(DifxDatastream *dd, const DifxFreq *df);
-int DifxDatastreamGetPhasecalTones(double *toneFreq, const DifxDatastream *dd, const DifxFreq *df, int maxCount);
+int DifxDatastreamGetPhasecalTones(double *toneFreq, const DifxDatastream *dd, const DifxFreq *df, int maxCount, int AllPcalTones);
 void deleteDifxDatastreamInternals(DifxDatastream *dd);
 void deleteDifxDatastreamArray(DifxDatastream *dd, int nDatastream);
 void fprintDifxDatastream(FILE *fp, const DifxDatastream *dd);

--- a/libraries/difxio/difxio/difx_input_merge.c
+++ b/libraries/difxio/difxio/difx_input_merge.c
@@ -19,11 +19,11 @@
 //===========================================================================
 // SVN properties (DO NOT CHANGE)
 //
-// $Id: difx_input_merge.c 9636 2020-07-31 02:13:03Z LeonidPetrov $
+// $Id: difx_input_merge.c 9728 2020-09-19 02:40:01Z LeonidPetrov $
 // $HeadURL: https://svn.atnf.csiro.au/difx/libraries/difxio/trunk/difxio/difx_input_merge.c $
-// $LastChangedRevision: 9636 $
+// $LastChangedRevision: 9728 $
 // $Author: LeonidPetrov $
-// $LastChangedDate: 2020-07-31 12:13:03 +1000 (Fri, 31 Jul 2020) $
+// $LastChangedDate: 2020-09-19 12:40:01 +1000 (Sat, 19 Sep 2020) $
 //
 //============================================================================
 
@@ -145,7 +145,7 @@ int areDifxInputsCompatible(const DifxInput *D1, const DifxInput *D2, const Difx
 
 		for(f = 0; f < D1->nFreq; ++f)
 		{
-			if(isSameDifxFreq(D1->freq + f, D2->freq + f) == 0)
+			if(isSameDifxFreq(D1->freq + f, D2->freq + f, D1->AllPcalTones) == 0)
 			{
 				++difxInputCompatibilityStatistics[DifxInputCompatibilityFreqSet];
 
@@ -292,6 +292,7 @@ DifxInput *mergeDifxInputs(const DifxInput *D1, const DifxInput *D2, const DifxM
 	D->nInChan = D1->nInChan;
 	D->nOutChan = D1->nOutChan;
 	D->AntPol   = D1->AntPol;
+	D->AllPcalTones = D1->AllPcalTones;
 	D->polxy2hv = D1->polxy2hv;
 	if(D1->visBufferLength > D2->visBufferLength)
 	{
@@ -328,7 +329,7 @@ DifxInput *mergeDifxInputs(const DifxInput *D1, const DifxInput *D2, const DifxM
 
 	/* merge DifxFreq table */
 	D->freq = mergeDifxFreqArrays(D1->freq, D1->nFreq,
-		D2->freq, D2->nFreq, freqIdRemap, &(D->nFreq));
+		D2->freq, D2->nFreq, freqIdRemap, &(D->nFreq), D->AllPcalTones);
 
 	/* merge DifxDatastream table */
 	D->datastream = mergeDifxDatastreamArrays(D1->datastream, 

--- a/libraries/difxio/difxio/difx_spacecraft.c
+++ b/libraries/difxio/difxio/difx_spacecraft.c
@@ -19,11 +19,11 @@
 //===========================================================================
 // SVN properties (DO NOT CHANGE)
 //
-// $Id: difx_spacecraft.c 7020 2015-09-25 14:38:50Z WalterBrisken $
+// $Id: difx_spacecraft.c 9729 2020-09-19 17:57:50Z WalterBrisken $
 // $HeadURL: https://svn.atnf.csiro.au/difx/libraries/difxio/trunk/difxio/difx_spacecraft.c $
-// $LastChangedRevision: 7020 $
+// $LastChangedRevision: 9729 $
 // $Author: WalterBrisken $
-// $LastChangedDate: 2015-09-26 00:38:50 +1000 (Sat, 26 Sep 2015) $
+// $LastChangedDate: 2020-09-20 03:57:50 +1000 (Sun, 20 Sep 2020) $
 //
 //============================================================================
 
@@ -253,12 +253,12 @@ static int computeDifxSpacecraftEphemeris_bsp(DifxSpacecraft *ds, double mjd0, d
 	{
 		double state[6], range;
 		long double jd;
-		char jdstr[24];
+		char jdstr[28];
 		double et;
 		
 		/* time to evaluate ephemeris */
 		jd = 2400000.5 + ds->pos[p].mjd + ds->pos[p].fracDay + ephemClockError/86400.0;
-		sprintf(jdstr, "JD %18.12Lf", jd);
+		sprintf(jdstr, "JD %18.12Lf UTC", jd);
 		str2et_c(jdstr, &et);
 
 		/* 399 is the earth geocenter */


### PR DESCRIPTION
r9733 | WalterBrisken | 2020-09-22 06:48:05 +1000 (Tue, 22 Sep 2020) | 1 line
fix logic issue

r9732 | GeoffreyCrew | 2020-09-22 00:43:48 +1000 (Tue, 22 Sep 2020) | 1 line
inserted missing HAS_MARK6META and fixed minor cmpiler warnings

r9731 | LeonidPetrov | 2020-09-20 05:15:54 +1000 (Sun, 20 Sep 2020) | 4 lines
Added in "difx2fits --help" description of environment variables
DIFX2FITS_UVFITS_DUMP, DIFX2FITS_UVFITS_DUMP_UTCMIN, and
DIFX2FITS_UVFITS_DUMP_UTCMAX used for debugging.

r9730 | WalterBrisken | 2020-09-20 04:42:14 +1000 (Sun, 20 Sep 2020) | 1 line
Fix some compiler warnings, avoid unnecessary use of strings, clean up code a bit

r9729 | WalterBrisken | 2020-09-20 03:57:50 +1000 (Sun, 20 Sep 2020) | 1 line
Fix compile error and some compile warnings

r9728 | LeonidPetrov | 2020-09-19 12:40:01 +1000 (Sat, 19 Sep 2020) | 17 lines
Update in difx2fits

  New option is added

--all-pcal-tones -A                  Extract all phase calibration tones

  This options overrides tone selection either specified in v2d file
o set by default in embedded in the difx input files and extracts
all the tines within recorded bandwidth. There are two side-effects.
If the phase calibration tone spacing is not commensurate to the IF width,
a situation may happen that the number of tones in different IFs may differ
by 1. When -A is applied the maximum number of tones is put in the
FITS-IDI. Unused slots for phase calibration frequency, phase and
amplitude are padded with zeroes. Without -A option IFs with the same
frequency range but with different phase calibration tones are considered
different. With -A option such IFs are considered identical.